### PR TITLE
User Show Page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,5 @@
+class UsersController < ApplicationController
+  def show
+    @user = User.find(params[:id])
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,4 +2,8 @@ class UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
   end
+
+  def edit
+    @user = User.find(params[:id])
+  end
 end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,1 @@
+<h2>Edit <%= @user.name %>'s Profile</h2>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,11 @@
+<h2><%= @user.name %></h2>
+
+<p>Email: <%= @user.email %></p>
+<p>Role: <%= @user.role %></p>
+<p>Active: <%= @user.active %></p>
+<p>Address: <%= @user.address %></p>
+<p>City: <%= @user.city %></p>
+<p>State: <%= @user.state %></p>
+<p>Zip Code: <%= @user.zip %></p>
+
+<%= link_to edit_user_path(@user) %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,4 +8,4 @@
 <p>State: <%= @user.state %></p>
 <p>Zip Code: <%= @user.zip %></p>
 
-<%= link_to edit_user_path(@user) %>
+<%= link_to "Edit Profile", edit_user_path(@user) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
-  resource :user, only: [:show]
+  resources :users, only: [:show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
+
+  resource :user, only: [:show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
-  resources :users, only: [:show]
+  resources :users, only: [:show, :edit]
 end

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe 'As a Registered User', type: :feature do
 
       click_on "Edit Profile"
 
-      expect(current_path).to eq("user/#{@user.id}/edit")
+      expect(current_path).to eq("/users/#{@user.id}/edit")
     end
   end
 end

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe 'As a Registered User', type: :feature do
   describe 'When I visit my own profile page' do
     before :each do
-      @user = User.create!(email: "test@test.com", password_digest: "test", role: 1, active: true, name: "Testy McTesterson", address: "123 Test St", city: "Testville", state: "Test", zip: "01234")
+      @user = User.create!(email: "test@test.com", password_digest: "t3s7", role: 1, active: true, name: "Testy McTesterson", address: "123 Test St", city: "Testville", state: "Test", zip: "01234")
     end
 
     it 'Then I can see all my information, except my password' do

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+RSpec.describe 'As a Registered User', type: :feature do
+  describe 'When I visit my own profile page' do
+    before :each do
+      @user = User.create!(email: "test@test.com", password_digest: "test", role: 1, active: true, name: "Testy McTesterson", address: "123 Test St", city: "Testville", state: "Test", zip: "01234")
+    end
+
+    it 'Then I can see all my information, except my password' do
+      visit user_path(@user)
+
+      expect(page).to have_content(@user.email)
+      expect(page).to have_content(@user.role)
+      expect(page).to have_content(@user.active)
+      expect(page).to have_content(@user.name)
+      expect(page).to have_content(@user.address)
+      expect(page).to have_content(@user.city)
+      expect(page).to have_content(@user.state)
+      expect(page).to have_content(@user.zip)
+
+      expect(page).to_not have_content(@user.password_digest)
+    end
+
+    it 'I see a link to edit my information' do
+      visit user_path(@user)
+
+      expect(page).to have_link("Edit Profile")
+
+      click_on "Edit Profile"
+
+      expect(current_path).to eq("user/#{@user.id}/edit")
+    end
+  end
+end


### PR DESCRIPTION
This PR brings in the main functionality of the User Show page. This view will display the information of a signed in, registered User. The current implementation is that a user can only look at their own page.
All information for a user is available, except for their Password in any way, shape, or form.
There is also a link to edit the users information, but that page/form will be built out elsewhere.

Resolves #66 