### PR TITLE
Routes and db updates, /profile path

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,26 +1,17 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
-  helper_method :current_user, :current_merchant, :current_admin
+  helper_method :current_user, :current_merchant?, :current_admin?
 
   def current_user
-    user = User.find(session[:user_id])
-    if user.role == 0
-      true
-    end
+    @current_user ||= User.find(session[:user_id]) if session[:user_id]
   end
 
-  def current_merchant
-    user = User.find(session[:user_id])
-    if user.role == 1
-      true
-    end
+  def current_merchant?
+    current_user && current_user.merchant?
   end
 
-  def current_admin
-    user = User.find(session[:user_id])
-    if user.role == 2
-      true
-    end
+  def current_admin?
+    current_user && current_user.admin?
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -22,12 +22,12 @@ class SessionsController < ApplicationController
 
 
   def redirects
-    if current_user
-      redirect_to user_path(session[:user_id])
-    elsif current_merchant
+    if current_merchant?
       redirect_to dashboard_path
-    else current_admin
+    elsif current_admin?
       redirect_to root_path
+    else
+      redirect_to profile_path
     end
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -23,7 +23,7 @@ class SessionsController < ApplicationController
 
   def redirects
     if current_user
-      redirect_to profile_path
+      redirect_to user_path(session[:user_id])
     elsif current_merchant
       redirect_to dashboard_path
     else current_admin

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,7 +14,7 @@ class UsersController < ApplicationController
     elsif @user.save
       session[:user_id] = @user.id
       flash[:notice] = "You are now registered and logged in."
-      redirect_to user_path(@user)
+      redirect_to profile_path
     else
       flash[:notice] = "That didn't work, please try again."
       render :new
@@ -22,11 +22,11 @@ class UsersController < ApplicationController
   end
 
   def show
-    @user = User.find(params[:id])
+    @user = current_user
   end
 
   def edit
-    @user = User.find(params[:id])
+    @user = current_user
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,8 +3,10 @@ class User < ApplicationRecord
   has_many :orders
 
   validates_presence_of :password_digest, :name, :address, :city, :state, :zip
-  
+
   validates :email, presence: true, uniqueness: true
 
   has_secure_password
+
+  enum role: ["user", "merchant", "admin"]
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,5 +8,5 @@ class User < ApplicationRecord
 
   has_secure_password
 
-  enum role: ["user", "merchant", "admin"]
+  enum role: ["default", "merchant", "admin"]
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
 
 
       <section class="register-link">
-        <%= link_to 'Register', new_user_path %>
+        <%= link_to 'Register', register_path %>
       </section>
     </ul>
 

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @user do |f| %>
+<%= form_for @user, url: register_path do |f| %>
 
 <p><%= f.label :name %></p>
 <%= f.text_field :name %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,8 @@ Rails.application.routes.draw do
 
   resources :items, only: [:index, :show]
 
+  resources :carts, only: [:create]
+
   resources :users, only:[:edit]
 
   get '/register', to: 'users#new'
@@ -12,7 +14,12 @@ Rails.application.routes.draw do
   get '/login', to: 'sessions#new', as: :login
   post '/login', to: 'sessions#create'
 
-  get '/profile/:id', to: 'users#show', as: :user
+  get '/profile', to: 'users#show'
 
   get '/dashboard', to: 'merchants#show'
+
+  namespace :admin do
+    resources :users, only: [:index]
+    get '/dashboard', to: 'users#show'
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,18 +1,18 @@
 Rails.application.routes.draw do
-
-
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'welcome#index'
 
-  get '/profile/:id', to: 'users#show', as: :user
-
   resources :items, only: [:index, :show]
 
-  resources :users, only:[:new, :create, :edit]
+  resources :users, only:[:edit]
+
+  get '/register', to: 'users#new'
+  post '/register', to: 'users#create'
 
   get '/login', to: 'sessions#new', as: :login
   post '/login', to: 'sessions#create'
 
-  get '/dashboard', to: 'merchants#show'
+  get '/profile/:id', to: 'users#show', as: :user
 
+  get '/dashboard', to: 'merchants#show'
 end

--- a/db/migrate/20190520222029_create_users.rb
+++ b/db/migrate/20190520222029_create_users.rb
@@ -3,7 +3,7 @@ class CreateUsers < ActiveRecord::Migration[5.1]
     create_table :users do |t|
       t.string :email
       t.string :password_digest
-      t.integer :role
+      t.integer :role, default: 0
       t.boolean :active
       t.string :name
       t.string :address

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,7 +51,7 @@ ActiveRecord::Schema.define(version: 20190520224827) do
   create_table "users", force: :cascade do |t|
     t.string "email"
     t.string "password_digest"
-    t.integer "role"
+    t.integer "role", default: 0
     t.boolean "active"
     t.string "name"
     t.string "address"

--- a/spec/features/users/login_spec.rb
+++ b/spec/features/users/login_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'User can login' do
 
       click_button('Login')
 
-      expect(current_path).to eq('/profile')
+      expect(current_path).to eq("/profile/#{@regular_user.id}")
       expect(page).to have_content('You are now logged in.')
     end
 

--- a/spec/features/users/login_spec.rb
+++ b/spec/features/users/login_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'User can login' do
 
       click_button('Login')
 
-      expect(current_path).to eq("/profile/#{@regular_user.id}")
+      expect(current_path).to eq("/profile")
       expect(page).to have_content('You are now logged in.')
     end
 

--- a/spec/features/users/new_spec.rb
+++ b/spec/features/users/new_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'New user form' do
         new_user = User.last
 
 
-        expect(current_path).to eq("/profile/#{new_user.id}")
+        expect(current_path).to eq("/profile")
 
         expect(page).to have_content("#{new_user.name}")
         expect(page).to have_content("Address: #{new_user.address}")

--- a/spec/features/users/new_spec.rb
+++ b/spec/features/users/new_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'New user form' do
           click_link('Register')
         end
 
-        expect(current_path).to eq(new_user_path)
+        expect(current_path).to eq(register_path)
 
         fill_in 'Name', with: 'User'
         fill_in 'Address', with: '1111 South One St.'

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -4,10 +4,12 @@ RSpec.describe 'As a Registered User', type: :feature do
   describe 'When I visit my own profile page' do
     before :each do
       @user = User.create!(email: "test@test.com", password_digest: "t3s7", role: 1, active: true, name: "Testy McTesterson", address: "123 Test St", city: "Testville", state: "Test", zip: "01234")
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
     end
 
     it 'Then I can see all my information, except my password' do
-      visit user_path(@user)
+      visit profile_path
 
       expect(page).to have_content(@user.email)
       expect(page).to have_content(@user.role)
@@ -22,7 +24,7 @@ RSpec.describe 'As a Registered User', type: :feature do
     end
 
     it 'I see a link to edit my information' do
-      visit user_path(@user)
+      visit profile_path
 
       expect(page).to have_link("Edit Profile")
 


### PR DESCRIPTION
This PR brings in a new set of Routes for future reference, and refactors the Users#show path to send to /profile instead. This turned out to be a major refactor for that, as we had already baked `user_path` functionality into a fair amount of specs and controllers.
We also added a default value for Users to have 0 for their Role. The 0 role has been assigned to "default", role 1 has been assigned to "merchant" and role 2 has been assigned to "admin".
