### PR TITLE
User Edit Page

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,6 +29,14 @@ class UsersController < ApplicationController
     @user = current_user
   end
 
+  def patch
+    user = current_user
+    user.update(strong_params)
+    flash[:notice] = "Your information has been updated!"
+
+    redirect_to profile_path
+  end
+
   private
 
   def password_confirmation

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,7 +29,7 @@ class UsersController < ApplicationController
     @user = current_user
   end
 
-  def patch
+  def update
     user = current_user
     user.update(strong_params)
     flash[:notice] = "Your information has been updated!"

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,1 +1,31 @@
 <h2>Edit <%= @user.name %>'s Profile</h2>
+
+<%= form_for @user, url: profile_edit_path do |f| %>
+
+<p><%= f.label :name %></p>
+<%= f.text_field :name %>
+
+<p><%= f.label :address %></p>
+<%= f.text_field :address %>
+
+<p><%= f.label :city %></p>
+<%= f.text_field :city %>
+
+<p><%= f.label :state %></p>
+<%= f.text_field :state %>
+
+<p><%= f.label :zip %></p>
+<%= f.text_field :zip %>
+
+<p><%= f.label :email %></p>
+<%= f.text_field :email %>
+
+<p><%= f.label :password %></p>
+<%= f.password_field :password %>
+
+<p><%= f.label :confirm_password, "Confirm Password" %></p>
+<%= f.password_field :confirm_password %>
+
+<%= f.submit "Edit User" %>
+
+<% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,4 +10,4 @@
 <p>State: <%= @user.state %></p>
 <p>Zip Code: <%= @user.zip %></p>
 
-<%= link_to "Edit Profile", edit_user_path(@user) %>
+<%= link_to "Edit Profile", profile_edit_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
   post '/login', to: 'sessions#create'
 
   get '/profile', to: 'users#show'
+  get '/profile/edit', to: 'users#edit'
 
   get '/dashboard', to: 'merchants#show'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,8 +6,6 @@ Rails.application.routes.draw do
 
   resources :carts, only: [:create]
 
-  resources :users, only:[:edit]
-
   get '/register', to: 'users#new'
   post '/register', to: 'users#create'
 
@@ -16,7 +14,7 @@ Rails.application.routes.draw do
 
   get '/profile', to: 'users#show'
   get '/profile/edit', to: 'users#edit'
-  patch 'profile/edit', to: 'users#patch'
+  patch 'profile/edit', to: 'users#update'
 
   get '/dashboard', to: 'merchants#show'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
 
   get '/profile', to: 'users#show'
   get '/profile/edit', to: 'users#edit'
+  patch 'profile/edit', to: 'users#patch'
 
   get '/dashboard', to: 'merchants#show'
 

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -53,6 +53,8 @@ RSpec.describe 'As a registered User', type: :feature do
         click_button "Edit User"
 
         expect(current_path).to eq(profile_path)
+
+        expect(page).to have_content("Your information has been updated!")
         expect(page).to have_content("Testerino")
       end
     end

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe 'As a registered User', type: :feature do
+  context 'Default user' do
+    describe 'And I click the link to edit my profile' do
+      before :each do
+        @user = User.create!(email: "test@test.com", password_digest: "t3s7", role: 1, active: true, name: "Testy McTesterson", address: "123 Test St", city: "Testville", state: "Test", zip: "01234")
+
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+      end
+
+      it 'Has the current path of /profile/edit' do
+        visit profile_path
+
+        click_link "Edit Profile"
+
+        expect(current_path).to eq(profile_edit_path)
+      end
+
+      it 'Has a form to modify my information' do
+        visit profile_edit_path
+
+        expect(page).to have_field("Name")
+        expect(page).to have_field("Password")
+        expect(page).to have_field("Confirm Password")
+        expect(page).to have_field("Address")
+        expect(page).to have_field("City")
+        expect(page).to have_field("State")
+        expect(page).to have_field("Zip")
+        expect(page).to have_field("Email")
+
+        expect(page).to have_button("Edit User")
+      end
+    end
+  end
+end

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -57,6 +57,42 @@ RSpec.describe 'As a registered User', type: :feature do
         expect(page).to have_content("Your information has been updated!")
         expect(page).to have_content("Testerino")
       end
+
+      it 'Can successfully edit all of my fields except password' do
+        visit profile_edit_path
+
+        fill_in "Name", with: "Testerino"
+        fill_in "Address", with: "455 Test Ave"
+        fill_in "City", with: "Testopolis"
+        fill_in "State", with: "Testafornia"
+        fill_in "Zip", with: "54321"
+        fill_in "Email", with: "test@test.net"
+
+        click_button "Edit User"
+
+        expect(current_path).to eq(profile_path)
+
+        expect(page).to have_content("Your information has been updated!")
+        expect(page).to have_content("Testerino")
+        expect(page).to have_content("455 Test Ave")
+        expect(page).to have_content("Testopolis")
+        expect(page).to have_content("Testafornia")
+        expect(page).to have_content("54321")
+        expect(page).to have_content("test@test.net")
+      end
+
+      it 'Can successfully update a password' do
+        visit profile_edit_path
+
+        fill_in "Password", with: "newtest"
+        fill_in "Confirm Password", with: "newtest"
+
+        click_button "Edit User"
+
+        expect(current_path).to eq(profile_path)
+        expect(page).to have_content("Your information has been updated!")
+        expect(@user.password_digest).to_not eq("t3s7")
+      end
     end
   end
 end

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -56,6 +56,8 @@ RSpec.describe 'As a registered User', type: :feature do
 
         expect(page).to have_content("Your information has been updated!")
         expect(page).to have_content("Testerino")
+
+        expect(@user.password_digest).to eq("t3s7")
       end
 
       it 'Can successfully edit all of my fields except password' do
@@ -79,6 +81,8 @@ RSpec.describe 'As a registered User', type: :feature do
         expect(page).to have_content("Testafornia")
         expect(page).to have_content("54321")
         expect(page).to have_content("test@test.net")
+
+        expect(@user.password_digest).to eq("t3s7")
       end
 
       it 'Can successfully update a password' do

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -31,6 +31,30 @@ RSpec.describe 'As a registered User', type: :feature do
 
         expect(page).to have_button("Edit User")
       end
+
+      it 'Has a form with my information already filled out, except Password/Confirm Password' do
+        visit profile_edit_path
+
+        expect(page).to have_field("Name", with: "Testy McTesterson")
+        expect(find_field("Password").value).blank?
+        expect(find_field("Confirm Password").value).blank?
+        expect(page).to have_field("Address", with: "123 Test St")
+        expect(page).to have_field("City", with: "Testville")
+        expect(page).to have_field("State", with: "Test")
+        expect(page).to have_field("Zip", with: "01234")
+        expect(page).to have_field("Email", with: "test@test.com")
+      end
+
+      it 'Can successfully edit one of my fields' do
+        visit profile_edit_path
+
+        fill_in "Name", with: "Testerino"
+
+        click_button "Edit User"
+
+        expect(current_path).to eq(profile_path)
+        expect(page).to have_content("Testerino")
+      end
     end
   end
 end

--- a/spec/features/users/show_spec.rb
+++ b/spec/features/users/show_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'As a Registered User', type: :feature do
 
       click_on "Edit Profile"
 
-      expect(current_path).to eq("/users/#{@user.id}/edit")
+      expect(current_path).to eq("/profile/edit")
     end
   end
 end


### PR DESCRIPTION
This PR brings in the functionality for a Default User to edit their information. This is done through the /profile page, and following through on the Edit Profile button.
The Default User will be served a form that is filled out with most of their existing information, everything except for their Password. They can change none or all of the information and it will send a PATCH request to the UsersController.
Fortunately, Rails Magic covers an empty string for Password, not changing the Password in that case.

Resolves #65 