### PR TITLE
Unique Email for Existing User Edit

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -37,7 +37,7 @@ class UsersController < ApplicationController
     if password_confirmation != true
       flash.now[:notice] = "Those passwords don't match."
       render :edit
-    elsif update_email_confirmation(@user.email) == true
+    elsif email_confirmation(@user.email) == true
       flash.now[:notice] = "That email address is already taken."
       render :edit
     elsif @user.update!(strong_params)
@@ -51,11 +51,7 @@ class UsersController < ApplicationController
 
   private
 
-  def email_confirmation
-    User.email_string.include?(params[:user][:email])
-  end
-
-  def update_email_confirmation(user_email = nil)
+  def email_confirmation(user_email = nil)
     (User.email_string - [user_email]).include?(params[:user][:email])
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -33,17 +33,32 @@ class UsersController < ApplicationController
   end
 
   def update
-    user = current_user
-    user.update(strong_params)
-    flash[:notice] = "Your information has been updated!"
-
-    redirect_to profile_path
+    @user = current_user
+    if password_confirmation != true
+      flash.now[:notice] = "Those passwords don't match."
+      render :edit
+    elsif update_email_confirmation(@user.email) != true
+      flash.now[:notice] = "That email address is already taken."
+      render :edit
+    elsif @user.update!(strong_params)
+      flash[:notice] = "Your information has been updated!"
+      redirect_to profile_path
+    else
+      flash.now[:notice] = "That didn't work, please try again."
+      render :edit
+    end
   end
 
   private
 
   def email_confirmation
     User.email_string.all? do |email|
+      params[:user][:email] != email
+    end
+  end
+
+  def update_email_confirmation(user_email = nil)
+    (User.email_string - [user_email]).all? do |email|
       params[:user][:email] != email
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,7 @@ class UsersController < ApplicationController
     if password_confirmation != true
       flash.now[:notice] = "Those passwords don't match."
       render :new
-    elsif email_confirmation != true
+    elsif email_confirmation == true
       flash.now[:notice] = "That email address is already taken."
       render :new
     elsif @user.save!
@@ -37,7 +37,7 @@ class UsersController < ApplicationController
     if password_confirmation != true
       flash.now[:notice] = "Those passwords don't match."
       render :edit
-    elsif update_email_confirmation(@user.email) != true
+    elsif update_email_confirmation(@user.email) == true
       flash.now[:notice] = "That email address is already taken."
       render :edit
     elsif @user.update!(strong_params)
@@ -52,15 +52,11 @@ class UsersController < ApplicationController
   private
 
   def email_confirmation
-    User.email_string.all? do |email|
-      params[:user][:email] != email
-    end
+    User.email_string.include?(params[:user][:email])
   end
 
   def update_email_confirmation(user_email = nil)
-    (User.email_string - [user_email]).all? do |email|
-      params[:user][:email] != email
-    end
+    (User.email_string - [user_email]).include?(params[:user][:email])
   end
 
   def password_confirmation

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -97,6 +97,21 @@ RSpec.describe 'As a registered User', type: :feature do
         expect(page).to have_content("Your information has been updated!")
         expect(@user.password_digest).to_not eq("t3s7")
       end
+
+      it 'Will not allow an already existing users email' do
+        other_user = User.create!(email: "test@test.net", password_digest: "t3s7", role: 1, active: true, name: "Testy McTesterson", address: "123 Test St", city: "Testville", state: "Test", zip: "01234")
+
+        visit profile_edit_path
+
+        fill_in "Email", with: "test@test.net"
+
+        click_button "Edit User"
+
+        expect(current_path).to eq(profile_edit_path)
+        expect(page).to have_content("That email address is already taken.")
+
+        expect(page).to have_field("Email", with: "test@test.com")
+      end
     end
   end
 end


### PR DESCRIPTION
This PR brings in the same logic from our User#create method to ensure that a User editing their profile is not able to change their Email Address to one already being used by another User.
This logic block also brings the Password confirmation as a bonus.

This PR also refactors the UsersController Email_confirmation method to use .include? instead. It also works for both the creation of a User, and for the updating of a User.
When Updating, you give it an argument of user_email, which is then removed from the pool of Existing Users. This allows a User to submit the SAME email while editing. Otherwise, that argument is ignored (as `nil`) and pulls all email addresses during creation.

Resolves #64 