### PR TITLE
User Orders Show page

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -3,4 +3,9 @@ class OrdersController < ApplicationController
     @user = current_user
     @orders = @user.orders
   end
+
+  def show
+    @order = Order.find(params[:id])
+    @order_items = @order.order_items
+  end
 end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -4,4 +4,8 @@ class OrderItem < ApplicationRecord
 
   validates_presence_of :quantity, :price
   validates_inclusion_of :fulfilled, in: [true, false]
+
+  def sub_total
+    quantity * price
+  end
 end

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -8,7 +8,7 @@
       <p>Last Updated: <%= order.last_updated %></p>
       <p>Current Status: <%= order.status.capitalize %></p>
       <p>Number of Items: <%= order.item_count %></p>
-      <p>Grand Total: $<%= order.grand_total %></p>
+      <p>Grand Total: <%= number_to_currency(order.grand_total, unit: "$") %></p>
     </section>
   <% end %>
 <% else %>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -6,7 +6,7 @@
       <%= link_to "Order ID: #{order.id}", profile_order_path(order) %>
       <p>Date Made: <%= order.date_made %></p>
       <p>Last Updated: <%= order.last_updated %></p>
-      <p>Current Status: <%= order.status.titlecase %></p>
+      <p>Current Status: <%= order.status.capitalize %></p>
       <p>Number of Items: <%= order.item_count %></p>
       <p>Grand Total: $<%= order.grand_total %></p>
     </section>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -3,7 +3,7 @@
 <% if @orders.count > 0 %>
   <% @orders.each do |order| %>
     <section id="order-<%= order.id %>">
-      <%= link_to "Order ID: #{order.id}", order %>
+      <%= link_to "Order ID: #{order.id}", profile_order_path(order) %>
       <p>Date Made: <%= order.date_made %></p>
       <p>Last Updated: <%= order.last_updated %></p>
       <p>Current Status: <%= order.status.titlecase %></p>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -1,0 +1,19 @@
+<h2>Order <%= @order.id %></h2>
+
+<p>Date Made: <%= @order.date_made %></p>
+<p>Last Updated: <%= @order.last_updated %></p>
+<p>Current Status: <%= @order.status.capitalize %></p>
+
+<% @order_items.each do |order_item| %>
+  <section id="order-item-<%= order_item.id %>">
+    <% item = order_item.item %>
+    <p><%= link_to "#{item.name}", item_path(item) %></p>
+    <p><%= item.description %></p>
+    <img src="<%= item.image %>" alt="<%= item.name %> Image">
+    <p>Quantity: <%= order_item.quantity %></p>
+    <p>Subtotal: <%= order_item.sub_total %></p>
+  </section>
+<% end %>
+
+<p>Number of Items: <%= @order.item_count %></p>
+<p>Grand Total: <%= @order.grand_total %></p>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -11,9 +11,9 @@
     <p><%= item.description %></p>
     <img src="<%= item.image %>" alt="<%= item.name %> Image">
     <p>Quantity: <%= order_item.quantity %></p>
-    <p>Subtotal: <%= order_item.sub_total %></p>
+    <p>Subtotal: <%= number_to_currency(order_item.sub_total, unit: "$") %></p>
   </section>
 <% end %>
 
 <p>Number of Items: <%= @order.item_count %></p>
-<p>Grand Total: <%= @order.grand_total %></p>
+<p>Grand Total: <%= number_to_currency(@order.grand_total, unit: "$") %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   resources :items, only: [:index, :show]
 
   resources :carts, only: [:create, :index] #added index as we need to show the cart -- User Story 2, Visitor Navigation
-  
+
   get '/register', to: 'users#new'
   post '/register', to: 'users#create'
 
@@ -17,8 +17,7 @@ Rails.application.routes.draw do
   get '/profile/edit', to: 'users#edit'
   patch '/profile/edit', to: 'users#update'
   get '/profile/orders', to: 'orders#index'
-
-  resources :orders, only: [:show]
+  get '/profile/orders/:id', to: 'orders#show', as: :profile_order
 
 
   get '/dashboard', to: 'merchants#show'

--- a/spec/features/users/default/orders_index_spec.rb
+++ b/spec/features/users/default/orders_index_spec.rb
@@ -109,5 +109,23 @@ RSpec.describe 'As a Registered User', type: :feature do
 
       expect(page).to have_content("You haven't made any orders yet!")
     end
+
+    it 'Has a link to the show page for each Order' do
+      visit profile_orders_path
+      click_on("Order ID: #{@order_1.id}")
+      expect(current_path).to eq("/profile/orders/#{@order_1.id}")
+
+      visit profile_orders_path
+      click_on("Order ID: #{@order_2.id}")
+      expect(current_path).to eq("/profile/orders/#{@order_2.id}")
+
+      visit profile_orders_path
+      click_on("Order ID: #{@order_3.id}")
+      expect(current_path).to eq("/profile/orders/#{@order_3.id}")
+
+      visit profile_orders_path
+      click_on("Order ID: #{@order_4.id}")
+      expect(current_path).to eq("/profile/orders/#{@order_4.id}")
+    end
   end
 end

--- a/spec/features/users/default/orders_show_spec.rb
+++ b/spec/features/users/default/orders_show_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'As a Registered User', type: :feature do
         expect(page).to have_content("#{@item_1.description}")
         expect(page).to have_css("img[src*='#{@item_1.image}']")
         expect(page).to have_content("Quantity: #{@order_item_1.quantity}")
-        expect(page).to have_content("Subtotal: #{@order_item_1.sub_total}")
+        expect(page).to have_content("Subtotal: $#{@order_item_1.sub_total}")
       end
 
       within("#order-item-#{@order_item_2.id}") do
@@ -47,7 +47,7 @@ RSpec.describe 'As a Registered User', type: :feature do
         expect(page).to have_content("#{@item_2.description}")
         expect(page).to have_css("img[src*='#{@item_2.image}']")
         expect(page).to have_content("Quantity: #{@order_item_2.quantity}")
-        expect(page).to have_content("Subtotal: #{@order_item_2.sub_total}")
+        expect(page).to have_content("Subtotal: $#{@order_item_2.sub_total}")
       end
 
       within("#order-item-#{@order_item_3.id}") do
@@ -55,11 +55,11 @@ RSpec.describe 'As a Registered User', type: :feature do
         expect(page).to have_content("#{@item_3.description}")
         expect(page).to have_css("img[src*='#{@item_3.image}']")
         expect(page).to have_content("Quantity: #{@order_item_3.quantity}")
-        expect(page).to have_content("Subtotal: #{@order_item_3.sub_total}")
+        expect(page).to have_content("Subtotal: $#{@order_item_3.sub_total}")
       end
 
       expect(page).to have_content("Number of Items: #{@order_1.item_count}")
-      expect(page).to have_content("Grand Total: #{@order_1.grand_total}")
+      expect(page).to have_content("Grand Total: $#{@order_1.grand_total}")
     end
   end
 end

--- a/spec/features/users/default/orders_show_spec.rb
+++ b/spec/features/users/default/orders_show_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe 'As a Registered User', type: :feature do
+  include ActiveSupport::Testing::TimeHelpers
+
+  describe 'When I visit of my Orders show pages' do
+    before :each do
+      @user = User.create!(email: "test@test.com", password_digest: "t3s7", role: 1, active: true, name: "Testy McTesterson", address: "123 Test St", city: "Testville", state: "Test", zip: "01234")
+
+      @merchant_1 = create(:user)
+      @merchant_2 = create(:user)
+
+      @item_1 = create(:item, user: @merchant_1)
+      @item_2 = create(:item, user: @merchant_1)
+      @item_3 = create(:item, user: @merchant_2)
+
+      travel_to Time.zone.local(2019, 04, 11, 8, 00, 00)
+      @order_1 = create(:order, user: @user)
+      travel_to Time.zone.local(2019, 04, 12, 8, 00, 00)
+      @order_1.update(status: 2)
+      travel_back
+
+      @order_item_1 = create(:order_item, order: @order_1, item: @item_1)
+      @order_item_2 = create(:order_item, order: @order_1, item: @item_2)
+      @order_item_3 = create(:order_item, order: @order_1, item: @item_3)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user)
+    end
+
+    it 'Has all the information for the Order' do
+      visit profile_order_path(@order_1)
+
+      expect(page).to have_content("Date Made: #{@order_1.date_made}")
+      expect(page).to have_content("Last Updated: #{@order_1.last_updated}")
+      expect(page).to have_content("Current Status: #{@order_1.status.capitalize}")
+
+      within("#order-item-#{@item_1}") do
+        expect(page).to have_content("#{@item_1.name}")
+        expect(page).to have_content("#{@item_1.description}")
+        expect(page).to have_content("#{@item_1.image}")
+        expect(page).to have_content("Quantity: #{@order_item_1.quantity}")
+        expect(page).to have_content("Subtotal: #{@order_item_1.sub_total}")
+      end
+
+      within("#order-item-#{@item_2}") do
+        expect(page).to have_content("#{@item_2.name}")
+        expect(page).to have_content("#{@item_2.description}")
+        expect(page).to have_content("#{@item_2.image}")
+        expect(page).to have_content("Quantity: #{@order_item_2.quantity}")
+        expect(page).to have_content("Subtotal: #{@order_item_2.sub_total}")
+      end
+
+      within("#order-item-#{@item_3}") do
+        expect(page).to have_content("#{@item_3.name}")
+        expect(page).to have_content("#{@item_3.description}")
+        expect(page).to have_content("#{@item_3.image}")
+        expect(page).to have_content("Quantity: #{@order_item_3.quantity}")
+        expect(page).to have_content("Subtotal: #{@order_item_3.sub_total}")
+      end
+
+      expect(page).to have_content("Number of Items: #{@order_1.item_count}")
+      expect(page).to have_content("Grand Total: #{@order_1.grand_total}")
+    end
+  end
+end

--- a/spec/features/users/default/orders_show_spec.rb
+++ b/spec/features/users/default/orders_show_spec.rb
@@ -34,26 +34,26 @@ RSpec.describe 'As a Registered User', type: :feature do
       expect(page).to have_content("Last Updated: #{@order_1.last_updated}")
       expect(page).to have_content("Current Status: #{@order_1.status.capitalize}")
 
-      within("#order-item-#{@item_1}") do
+      within("#order-item-#{@order_item_1.id}") do
         expect(page).to have_content("#{@item_1.name}")
         expect(page).to have_content("#{@item_1.description}")
-        expect(page).to have_content("#{@item_1.image}")
+        expect(page).to have_css("img[src*='#{@item_1.image}']")
         expect(page).to have_content("Quantity: #{@order_item_1.quantity}")
         expect(page).to have_content("Subtotal: #{@order_item_1.sub_total}")
       end
 
-      within("#order-item-#{@item_2}") do
+      within("#order-item-#{@order_item_2.id}") do
         expect(page).to have_content("#{@item_2.name}")
         expect(page).to have_content("#{@item_2.description}")
-        expect(page).to have_content("#{@item_2.image}")
+        expect(page).to have_css("img[src*='#{@item_2.image}']")
         expect(page).to have_content("Quantity: #{@order_item_2.quantity}")
         expect(page).to have_content("Subtotal: #{@order_item_2.sub_total}")
       end
 
-      within("#order-item-#{@item_3}") do
+      within("#order-item-#{@order_item_3.id}") do
         expect(page).to have_content("#{@item_3.name}")
         expect(page).to have_content("#{@item_3.description}")
-        expect(page).to have_content("#{@item_3.image}")
+        expect(page).to have_css("img[src*='#{@item_3.image}']")
         expect(page).to have_content("Quantity: #{@order_item_3.quantity}")
         expect(page).to have_content("Subtotal: #{@order_item_3.sub_total}")
       end

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -10,4 +10,22 @@ RSpec.describe OrderItem, type: :model do
     it { should validate_presence_of :quantity}
     it { should validate_presence_of :price}
   end
+
+  describe 'instance methods' do
+    before :each do
+      @user = User.create!(email: "test@test.com", password_digest: "t3s7", role: 1, active: true, name: "Testy McTesterson", address: "123 Test St", city: "Testville", state: "Test", zip: "01234")
+
+      @merchant_1 = create(:user)
+
+      @item_1 = create(:item, user: @merchant_1)
+
+      @order_1 = create(:order, user: @user)
+
+      @order_item_1 = create(:order_item, order: @order_1, item: @item_1, quantity: 2)
+    end
+
+    it '#sub_total' do
+      expect(@order_item_1.sub_total).to eq(19.98)
+    end
+  end
 end


### PR DESCRIPTION
This PR brings in the Default User Order Show page, and the necessary methods needed to present needed information.
The Order show page will provide all info that we would see on the Orders index, but with added sections for each included Item. These sections include name, description, image, price, and subtotal. This Subtotal required an instance method, which is called on an OrderItem. An OrderItem has the knowledge of quantity of items, and item price, which allows us to return the subtotal value.
This PR also refactored some display of Grand Totals on Orders as well, using the #number_to_currency method in ActiveView.

Resolves #54 