### PR TITLE
Story 20 fix

### DIFF
--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -40,7 +40,7 @@
           <li class="list-group-item">Inventory: <%= item.inventory %></li>
           <li class="list-group-item">Price: $<%= item.price %><br></li>
         </ul>
-        <button class="btn btn-primary"><%= button_to "Add To Cart", carts_path(item_id: item.id) %></button>
+        <button class="btn btn-primary"><%= link_to "Add To Cart", carts_path(item_id: item.id), method: :post, style:"color:white;" %></button>
       </div>
     </section>
   <% end %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -19,7 +19,7 @@
         <% end %>
       </ul>
       <% if current_user.nil? || current_user.default? %>
-        <%= link_to "Add to Cart", root_path %>
+        <%= link_to "Add to Cart", carts_path(item_id: @item.id), method: :post %>
       <% end %>
     </div>
   </div>

--- a/spec/features/carts/show_spec.rb
+++ b/spec/features/carts/show_spec.rb
@@ -45,18 +45,18 @@ describe 'As a visitor or a registered user' do
       visit items_path
 
       within "#item-#{@item_1.id}" do
-        click_button "Add To Cart"
+        click_link "Add To Cart"
       end
 
       within "#item-#{@item_2.id}" do
-        click_button "Add To Cart"
-        click_button "Add To Cart"
+        click_link "Add To Cart"
+        click_link "Add To Cart"
       end
 
       within "#item-#{@item_3.id}" do
-        click_button "Add To Cart"
-        click_button "Add To Cart"
-        click_button "Add To Cart"
+        click_link "Add To Cart"
+        click_link "Add To Cart"
+        click_link "Add To Cart"
       end
 
       visit carts_path

--- a/spec/features/items/index_spec.rb
+++ b/spec/features/items/index_spec.rb
@@ -136,14 +136,14 @@ RSpec.describe 'as a visitor' do
       expect(page).to have_content("(0)")
 
       within "#item-#{@item_1.id}" do
-        click_button "Add To Cart"
+        click_link "Add To Cart"
       end
 
       expect(page).to have_content("#{@item_1.name} has been added to your cart")
       expect(page).to have_content("(1)")
 
       within "#item-#{@item_2.id}" do
-        click_button "Add To Cart"
+        click_link "Add To Cart"
       end
 
       expect(page).to have_content("#{@item_2.name} has been added to your cart")

--- a/spec/features/items/show_spec.rb
+++ b/spec/features/items/show_spec.rb
@@ -38,10 +38,10 @@ RSpec.describe 'As any kind of user on the system' do
       OrderItem.create!(item: @item_4, order: order_10, quantity: 3, price: 11.99, fulfilled: false, created_at: 8.days.ago, updated_at: 1.days.ago)
       OrderItem.create!(item: @item_5, order: order_11, quantity: 1, price: 21.99, fulfilled: false, created_at: 9.days.ago, updated_at: 1.days.ago)
     end
-    
+
     it 'any my url path is correct' do
       visit items_path
-      
+
       within "#item-#{@item_1.id}" do
         click_on(@item_1.name)
       end
@@ -73,7 +73,7 @@ RSpec.describe 'As any kind of user on the system' do
       it 'as a regular user' do
         user = User.create!(email: "test@test.com", password_digest: "t3s7", role: :default, active: true, name: "Testy McTesterson", address: "123 Test St", city: "Testville", state: "Test", zip: "01234")
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
-    
+
         visit item_path(@item_1.id)
 
         expect(page).to have_link('Add to Cart')
@@ -95,6 +95,17 @@ RSpec.describe 'As any kind of user on the system' do
         visit item_path(@item_1.id)
 
         expect(page).to have_no_link('Add to Cart')
+      end
+
+      # The bulk of this functionality is tested in carts show spec
+      it 'successfully adds items to cart' do
+        visit item_path(@item_1.id)
+
+        click_link "Add to Cart"
+
+        expect(current_path).to eq(items_path)
+        expect(page).to have_content("#{@item_1.name} has been added to your cart")
+        expect(page).to have_content("(1)")
       end
     end
   end

--- a/spec/features/users/logout_spec.rb
+++ b/spec/features/users/logout_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe 'when logging out' do
 
     it 'logs out and clears cart' do
       visit items_path
-      click_button "Add To Cart"
-      click_button "Add To Cart"
+      click_link "Add To Cart"
+      click_link "Add To Cart"
 
       visit login_path
 


### PR DESCRIPTION
## What does this PR do?

- Adds spec for adding items to cart on item show page
- Changes clicking of add to cart to link instead of button on all feature tests
- Changes addd to cart button to link on items index page
- Adds correct link, path, and method to Add to Cart link on items show page

#### What fix was made?
- When I originally completed this card, I put the button to add item to cart on the items index page instead of the items show page
  - To fix this, I added a link to add items to cart on the items show page
  - There's now a button to add and item to a cart from the items show page AND the items index page