### PR TITLE
User orders cancel

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -8,4 +8,17 @@ class OrdersController < ApplicationController
     @order = Order.find(params[:id])
     @order_items = @order.order_items
   end
+
+  def destroy
+    @order = Order.find(params[:id])
+    @order.update(status: :cancelled)
+
+    @order.order_items.each do |order_item|
+      order_item.update(fulfilled: false)
+    end
+
+    flash[:notice] = "#{@order.id} has been cancelled."
+
+    redirect_to profile_orders_path
+  end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -12,11 +12,9 @@ class OrdersController < ApplicationController
   def destroy
     @order = Order.find(params[:id])
     @order.update(status: :cancelled)
-
     @order.order_items.each do |order_item|
       order_item.update(fulfilled: false)
     end
-
     flash[:notice] = "#{@order.id} has been cancelled."
 
     redirect_to profile_orders_path

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -5,7 +5,24 @@ class OrderItem < ApplicationRecord
   validates_presence_of :quantity, :price
   validates_inclusion_of :fulfilled, in: [true, false]
 
+  after_save :update_inventory
+
   def sub_total
     quantity * price
+  end
+
+  private
+
+  def update_inventory
+    if saved_change_to_fulfilled?
+
+      if fulfilled
+        new_inventory = item.inventory - quantity
+        item.update(inventory: new_inventory)
+      else
+        new_inventory = item.inventory + quantity
+        item.update(inventory: new_inventory)
+      end
+    end
   end
 end

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -18,6 +18,5 @@
 <p>Number of Items: <%= @order.item_count %></p>
 <p>Grand Total: <%= number_to_currency(@order.grand_total, unit: "$") %></p>
 
-<% if @order.pending?%>
-  <%= button_to "Cancel Order", profile_order_path(@order), method: "delete" %>
-<% end %>
+
+<%= button_to "Cancel Order", profile_order_path(@order), method: "delete", disabled: !@order.pending? %>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -17,3 +17,7 @@
 
 <p>Number of Items: <%= @order.item_count %></p>
 <p>Grand Total: <%= number_to_currency(@order.grand_total, unit: "$") %></p>
+
+<% if @order.pending?%>
+  <%= button_to "Cancel Order", profile_order_path(@order), method: "delete" %>
+<% end %>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -20,3 +20,6 @@
 
 
 <%= button_to "Cancel Order", profile_order_path(@order), method: "delete", disabled: !@order.pending? %>
+<% if !@order.pending? %>
+  <p>You can only cancel orders that are pending!</p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,8 +18,12 @@ Rails.application.routes.draw do
   get '/profile', to: 'users#show'
   get '/profile/edit', to: 'users#edit'
   patch '/profile/edit', to: 'users#update'
-  get '/profile/orders', to: 'orders#index'
-  get '/profile/orders/:id', to: 'orders#show', as: :profile_order
+  scope :profile do
+    # resources :users, only: [:show, :edit, :update], as: :profile
+    resources :orders, only: [:show, :index, :destroy], as: :profile_orders
+    # get '/profile/orders', to: 'orders#index'
+    # get '/profile/orders/:id', to: 'orders#show'
+  end
 
 
   get '/dashboard', to: 'merchants#show'

--- a/spec/features/users/default/orders_show_spec.rb
+++ b/spec/features/users/default/orders_show_spec.rb
@@ -61,5 +61,29 @@ RSpec.describe 'As a Registered User', type: :feature do
       expect(page).to have_content("Number of Items: #{@order_1.item_count}")
       expect(page).to have_content("Grand Total: $#{@order_1.grand_total}")
     end
+
+    it 'I can cancel the order if it is still pending' do
+      @order_1.update!(status: :pending)
+      visit profile_order_path(@order_1)
+
+      expect(page).to have_content("Current Status: Pending")
+      expect(page).to have_button("Cancel Order")
+
+      click_button "Cancel Order"
+
+      expect(@order_item_1.fullfilled).to be_falsy
+      expect(@order_item_2.fullfilled).to be_falsy
+      expect(@order_item_3.fullfilled).to be_falsy
+
+      # Expectations for Merchant Inventory being returned pending, need functionality
+
+      expect(current_path).to eq(profile_path)
+
+      expect(page).to have_content("#{@order_1.id} has been cancelled.")
+
+      within("#order-#{@order_1.id}") do
+        expect(page).to have_content("Current Status: Cancelled")
+      end
+    end
   end
 end

--- a/spec/features/users/default/orders_show_spec.rb
+++ b/spec/features/users/default/orders_show_spec.rb
@@ -91,6 +91,7 @@ RSpec.describe 'As a Registered User', type: :feature do
 
       expect(page).to have_content("Current Status: Shipped")
       expect(page).to have_button("Cancel Order", disabled: true)
+      expect(page).to have_content("You can only cancel orders that are pending!")
     end
   end
 end

--- a/spec/features/users/default/orders_show_spec.rb
+++ b/spec/features/users/default/orders_show_spec.rb
@@ -64,6 +64,12 @@ RSpec.describe 'As a Registered User', type: :feature do
 
     it 'I can cancel the order if it is still pending' do
       @order_1.update!(status: :pending)
+      @item_2.update!(inventory: 3)
+      @order_item_2.update!(fulfilled: true)
+      @item_2.reload
+      @order_item_2.reload
+      expect(@item_2.inventory).to eq(2)
+
       visit profile_order_path(@order_1)
 
       expect(page).to have_content("Current Status: Pending")
@@ -71,11 +77,15 @@ RSpec.describe 'As a Registered User', type: :feature do
 
       click_button "Cancel Order"
 
-      expect(@order_item_1.fulfilled).to be_falsy
-      expect(@order_item_2.fulfilled).to be_falsy
-      expect(@order_item_3.fulfilled).to be_falsy
+      @order_item_1.reload
+      @order_item_2.reload
+      @order_item_3.reload
+      expect(@order_item_1.fulfilled).to be false
+      expect(@order_item_2.fulfilled).to be false
+      expect(@order_item_3.fulfilled).to be false
 
-      # Expectations for Merchant Inventory being returned pending, need functionality
+      @item_2.reload
+      expect(@item_2.inventory).to eq(3)
 
       expect(current_path).to eq(profile_orders_path)
 

--- a/spec/features/users/default/orders_show_spec.rb
+++ b/spec/features/users/default/orders_show_spec.rb
@@ -71,13 +71,13 @@ RSpec.describe 'As a Registered User', type: :feature do
 
       click_button "Cancel Order"
 
-      expect(@order_item_1.fullfilled).to be_falsy
-      expect(@order_item_2.fullfilled).to be_falsy
-      expect(@order_item_3.fullfilled).to be_falsy
+      expect(@order_item_1.fulfilled).to be_falsy
+      expect(@order_item_2.fulfilled).to be_falsy
+      expect(@order_item_3.fulfilled).to be_falsy
 
       # Expectations for Merchant Inventory being returned pending, need functionality
 
-      expect(current_path).to eq(profile_path)
+      expect(current_path).to eq(profile_orders_path)
 
       expect(page).to have_content("#{@order_1.id} has been cancelled.")
 

--- a/spec/features/users/default/orders_show_spec.rb
+++ b/spec/features/users/default/orders_show_spec.rb
@@ -85,5 +85,12 @@ RSpec.describe 'As a Registered User', type: :feature do
         expect(page).to have_content("Current Status: Cancelled")
       end
     end
+
+    it 'Should have a disabled cancel button if the order is not pending' do
+      visit profile_order_path(@order_1)
+
+      expect(page).to have_content("Current Status: Shipped")
+      expect(page).to have_button("Cancel Order", disabled: true)
+    end
   end
 end


### PR DESCRIPTION
This PR brings in the functionality of a User cancelling one of their Orders, and all the associated actions that happen because of it. An Order can only be cancelled if it is in a Pending state. The User is  given a button to click on, but it will be disabled unless the Order is Pending.
When an Order is cancelled, it simultaneously updates the Order status to Cancelled, updates all Order Items to Fulfilled:False, and all Items have their previously spoken for Inventory returned to the Merchants. This requires the OrdersController Destroy method to iterate through Order Items and change their Fulfilled status to False.
Once an Order Item fulfillment status changes (to True or False), the Model will modify the Inventory of the corresponding Item. It will reduce the Inventory by the Order Items quantity if True, and add the quantity if False.

Resolves. #53 