### PR TITLE
Order Fulfillment Auto > Packaged

### DIFF
--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -24,4 +24,10 @@ class Order < ApplicationRecord
       item.price * item.quantity
     end
   end
+
+  def check_fulfillments
+    if order_items.all? {|order_item| order_item.fulfilled}
+      update(status: :packaged)
+    end
+  end
 end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -5,7 +5,7 @@ class OrderItem < ApplicationRecord
   validates_presence_of :quantity, :price
   validates_inclusion_of :fulfilled, in: [true, false]
 
-  after_save :update_inventory
+  after_save :update_inventory, :check_order
 
   def sub_total
     quantity * price
@@ -22,6 +22,14 @@ class OrderItem < ApplicationRecord
       else
         new_inventory = item.inventory + quantity
         item.update(inventory: new_inventory)
+      end
+    end
+  end
+
+  def check_order
+    if saved_change_to_fulfilled?
+      if fulfilled
+        order.check_fulfillments
       end
     end
   end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -81,5 +81,31 @@ RSpec.describe Order, type: :model do
       expect(@order_3.grand_total).to eq(19.98)
       expect(@order_4.grand_total).to eq(39.96)
     end
+
+    it '#check_fulfillments' do
+      user = User.create!(email: "not_test@test.com", password_digest: "t3s7", role: 1, active: true, name: "Testy McTesterson", address: "123 Test St", city: "Testville", state: "Test", zip: "01234")
+      merchant_1 = create(:user)
+      item_1 = create(:item, user: merchant_1)
+      item_2 = create(:item, user: merchant_1)
+      item_3 = create(:item, user: merchant_1)
+      order_1 = create(:order, user: user, status: :pending)
+      order_item_1 = create(:order_item, order: order_1, item: item_1)
+      order_item_2 = create(:order_item, order: order_1, item: item_2)
+      order_item_3 = create(:order_item, order: order_1, item: item_3)
+
+      expect(order_1.status).to eq("pending")
+
+      order_item_1.update!(fulfilled: true)
+      order_item_2.update!(fulfilled: true)
+      order_item_1.reload
+      order_item_2.reload
+      order_1.reload
+      expect(order_1.status).to eq("pending")
+
+      order_item_3.update!(fulfilled: true)
+      order_item_3.reload
+      order_1.reload
+      expect(order_1.status).to eq("packaged")
+    end
   end
 end


### PR DESCRIPTION
This PR brings in the functionality of an Order automatically changing from Pending to Packaged if all of its OrderItems have been fulfilled. This requires a #check_fulfillments method on the Order to .all? the OrderItems for their fulfillment status.
#check_fulfillments gets called by each OrderItem after_save and when :fulfilled is changed. This causes the Order to #check_fulfillments every time an OrderItem:fulfilled is updated.

Resolves #52 