### PR TITLE
Admin Ship Order

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,0 +1,8 @@
+class Admin::OrdersController < ApplicationController
+  def update
+    @order = Order.find(params[:id])
+    @order.update(status: :shipped)
+
+    redirect_to admin_dashboard_path
+  end
+end

--- a/app/views/admin/users/dashboard.html.erb
+++ b/app/views/admin/users/dashboard.html.erb
@@ -39,7 +39,7 @@
                   <td><%= order.id  %></td>
                   <td><%= order.user.name %></td>
                   <td><%= order.created_at.strftime("%b %d, %Y") %></td>
-                  <td><%= order.status.titlecase %><%= + ": Ready to ship!" if order.status == "packaged" %><%= button_to "Ship Order", admin_order_path(order), action: "patch" if order.status == "packaged" %></td>
+                  <td><%= order.status.titlecase %><%= + ": Ready to ship!" if order.status == "packaged" %><%= button_to "Ship Order", admin_order_path(order), method: "patch" if order.status == "packaged" %></td>
                   <%# <td><%= button_to "Delete Order", root_path, class:"btn btn-primary" /td> %>
                 </tr>
               <% end %>

--- a/app/views/admin/users/dashboard.html.erb
+++ b/app/views/admin/users/dashboard.html.erb
@@ -39,7 +39,7 @@
                   <td><%= order.id  %></td>
                   <td><%= order.user.name %></td>
                   <td><%= order.created_at.strftime("%b %d, %Y") %></td>
-                  <td><%= order.status.titlecase %></td>
+                  <td><%= order.status.titlecase %><%= + ": Ready to ship!" if order.status == "packaged" %><%= button_to "Ship Order", dashboard_order_path(order), action: "patch" if order.status == "packaged" %></td>
                   <%# <td><%= button_to "Delete Order", root_path, class:"btn btn-primary" /td> %>
                 </tr>
               <% end %>
@@ -48,5 +48,5 @@
         </div>
       </div>
     </div>
-  </div>  
+  </div>
 </div>

--- a/app/views/admin/users/dashboard.html.erb
+++ b/app/views/admin/users/dashboard.html.erb
@@ -39,7 +39,7 @@
                   <td><%= order.id  %></td>
                   <td><%= order.user.name %></td>
                   <td><%= order.created_at.strftime("%b %d, %Y") %></td>
-                  <td><%= order.status.titlecase %><%= + ": Ready to ship!" if order.status == "packaged" %><%= button_to "Ship Order", dashboard_order_path(order), action: "patch" if order.status == "packaged" %></td>
+                  <td><%= order.status.titlecase %><%= + ": Ready to ship!" if order.status == "packaged" %><%= button_to "Ship Order", admin_order_path(order), action: "patch" if order.status == "packaged" %></td>
                   <%# <td><%= button_to "Delete Order", root_path, class:"btn btn-primary" /td> %>
                 </tr>
               <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
 
   scope module: 'merchants', path: 'dashboard', as: :dashboard do
     resources :items, only: [:index, :new, :edit, :show, :destroy]
-    resources :orders, only: [:index, :show, :edit, :update]
+    resources :orders, only: [:index, :show, :edit]
   end
 
   namespace :admin do
@@ -44,5 +44,6 @@ Rails.application.routes.draw do
     get '/dashboard', to: 'users#dashboard'
     get '/merchants/:id', to: 'merchants#show'
     patch '/merchant/edit', to: 'merchants#edit'
+    resources :orders, only: [:update]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
 
   scope module: 'merchants', path: 'dashboard', as: :dashboard do
     resources :items, only: [:index, :new, :edit, :show, :destroy]
-    resources :orders, only: [:index, :show, :edit]
+    resources :orders, only: [:index, :show, :edit, :update]
   end
 
   namespace :admin do

--- a/spec/features/admin/users/dashboard_spec.rb
+++ b/spec/features/admin/users/dashboard_spec.rb
@@ -61,14 +61,12 @@ RSpec.describe 'As an admin user' do
       visit admin_dashboard_path
 
       within "#order-#{@o1.id}" do
-        expect(page).to have_content("Current Status: Packaged")
-        expect(page).to have_content("Ready to ship!")
+        expect(page).to have_content("Packaged: Ready to ship!")
         expect(page).to have_button("Ship Order")
       end
 
       within "#order-#{@o5.id}" do
-        expect(page).to have_content("Current Status: Packaged")
-        expect(page).to have_content("Ready to ship!")
+        expect(page).to have_content("Packaged: Ready to ship!")
         expect(page).to have_button("Ship Order")
       end
     end

--- a/spec/features/admin/users/dashboard_spec.rb
+++ b/spec/features/admin/users/dashboard_spec.rb
@@ -70,5 +70,20 @@ RSpec.describe 'As an admin user' do
         expect(page).to have_button("Ship Order")
       end
     end
+
+    it 'When I click Ship Order, the order status is changed to Shipped' do
+      visit admin_dashboard_path
+
+      within "#order-#{@o1.id}" do
+        click_button "Ship Order"
+      end
+
+      expect(current_path).to eq(admin_dashboard_path)
+
+      within "#order-#{@o1.id}" do
+        expect(page).to have_content("Shipped")
+        # Expectation for Cancel button to not be enabled requires US # 63
+      end
+    end
   end
 end

--- a/spec/features/admin/users/dashboard_spec.rb
+++ b/spec/features/admin/users/dashboard_spec.rb
@@ -79,6 +79,7 @@ RSpec.describe 'As an admin user' do
       end
 
       expect(current_path).to eq(admin_dashboard_path)
+      @o1.reload
 
       within "#order-#{@o1.id}" do
         expect(page).to have_content("Shipped")

--- a/spec/features/admin/users/dashboard_spec.rb
+++ b/spec/features/admin/users/dashboard_spec.rb
@@ -54,7 +54,23 @@ RSpec.describe 'As an admin user' do
         expect(text.index("#{@o6.id} #{@o6.user.name}") < text.index("#{@o7.id} #{@o7.user.name}")).to be true
         expect(text.index("#{@o7.id} #{@o7.user.name}") < text.index("#{@o3.id} #{@o3.user.name}")).to be true
         expect(text.index("#{@o3.id} #{@o3.user.name}") < text.index("#{@o4.id} #{@o4.user.name}")).to be true
+      end
     end
+
+    it 'I see any packaged orders ready to ship' do
+      visit admin_dashboard_path
+
+      within "#order-#{@o1.id}" do
+        expect(page).to have_content("Current Status: Packaged")
+        expect(page).to have_content("Ready to ship!")
+        expect(page).to have_button("Ship Order")
+      end
+
+      within "#order-#{@o5.id}" do
+        expect(page).to have_content("Current Status: Packaged")
+        expect(page).to have_content("Ready to ship!")
+        expect(page).to have_button("Ship Order")
+      end
     end
   end
 end


### PR DESCRIPTION
This PR brings in the functionality for an Admin user to Ship an Order that has all of its Items fulfilled by the Merchants, changing the status from Packaged to Shipped.
This functionality is provided by an Admin::OrdersController, and an additional button on the Admin Dashboard next to any Packaged orders in the display table. This Button will send a Patch request to the Controller, which then finds the Order, changes the status, and sends the User back to the Admin Dashboard. This can be refactored in the future with a BaseController.
This button and message about Shipping an Order will only appear in the View if the Order is in the Packaged status.

Resolves #50 