### PR TITLE
Merchant Order Show page

### DIFF
--- a/app/controllers/merchants/orders_controller.rb
+++ b/app/controllers/merchants/orders_controller.rb
@@ -1,0 +1,8 @@
+class Merchants::OrdersController <ApplicationController
+  def show
+    @merchant = current_user
+    @order = Order.find(params[:id])
+    @user = @order.user
+    @order_items = @order.order_items.map {|order_item| order_item if order_item.item.user_id == @merchant.id}.compact
+  end
+end

--- a/app/views/merchants/orders/show.html.erb
+++ b/app/views/merchants/orders/show.html.erb
@@ -1,0 +1,4 @@
+<h2>Order <%= @order.id %></h2>
+
+<p>Name: <%= @user.name %></p>
+<p>Address: <%= @user.address %>, <%= @user.city %>, <%= @user.state %>, <%= @user.zip %></p>

--- a/app/views/merchants/orders/show.html.erb
+++ b/app/views/merchants/orders/show.html.erb
@@ -2,3 +2,13 @@
 
 <p>Name: <%= @user.name %></p>
 <p>Address: <%= @user.address %>, <%= @user.city %>, <%= @user.state %>, <%= @user.zip %></p>
+
+<% @order_items.each do |order_item| %>
+<% item = order_item.item %>
+  <section id="item-<%= item.id %>">
+    <%= link_to item.name, item_path(item) %>
+    <img src=<%= item.image %> %> alt="<%= item.name %> Image">
+    <p><%= item.price %></p>
+    <p><%= order_item.quantity %></p>
+  </section>
+<% end %>

--- a/spec/features/merchants/orders/show_spec.rb
+++ b/spec/features/merchants/orders/show_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe 'As a merchant', type: :feature do
+  describe 'When I visit an order show page from my Dasboard' do
+    before :each do
+      @user = User.create!(email: "test@test.com", password_digest: "t3s7", role: 1, active: true, name: "Testy McTesterson", address: "123 Test St", city: "Testville", state: "Test", zip: "01234")
+
+      @merchant_1 = create(:user, role: 1)
+      @merchant_2 = create(:user, role: 1)
+
+      @item_1 = create(:item, user: @merchant_1)
+      @item_2 = create(:item, user: @merchant_1)
+      @item_3 = create(:item, user: @merchant_2)
+
+      travel_to Time.zone.local(2019, 04, 11, 8, 00, 00)
+      @order = create(:order, user: @user)
+      travel_back
+
+      @order_item_1 = create(:order_item, order: @order_1, item: @item_1)
+      @order_item_2 = create(:order_item, order: @order_1, item: @item_2)
+      @order_item_3 = create(:order_item, order: @order_1, item: @item_3)
+
+      allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant_1)
+    end
+
+    it 'Displays the Orders User information' do
+      visit merchant_order_path(@order)
+
+      expect(page).to have_content("Name: Testy McTesterson")
+      expect(page).to have_content("Address: 123 Test St, Testville, Test, 01234")
+    end
+  end
+end

--- a/spec/features/merchants/orders/show_spec.rb
+++ b/spec/features/merchants/orders/show_spec.rb
@@ -12,19 +12,17 @@ RSpec.describe 'As a merchant', type: :feature do
       @item_2 = create(:item, user: @merchant_1)
       @item_3 = create(:item, user: @merchant_2)
 
-      travel_to Time.zone.local(2019, 04, 11, 8, 00, 00)
       @order = create(:order, user: @user)
-      travel_back
 
-      @order_item_1 = create(:order_item, order: @order_1, item: @item_1)
-      @order_item_2 = create(:order_item, order: @order_1, item: @item_2)
-      @order_item_3 = create(:order_item, order: @order_1, item: @item_3)
+      @order_item_1 = create(:order_item, order: @order, item: @item_1)
+      @order_item_2 = create(:order_item, order: @order, item: @item_2)
+      @order_item_3 = create(:order_item, order: @order, item: @item_3)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant_1)
     end
 
     it 'Displays the Orders User information' do
-      visit merchant_order_path(@order)
+      visit dashboard_order_path(@order)
 
       expect(page).to have_content("Name: Testy McTesterson")
       expect(page).to have_content("Address: 123 Test St, Testville, Test, 01234")

--- a/spec/features/merchants/orders/show_spec.rb
+++ b/spec/features/merchants/orders/show_spec.rb
@@ -27,5 +27,25 @@ RSpec.describe 'As a merchant', type: :feature do
       expect(page).to have_content("Name: Testy McTesterson")
       expect(page).to have_content("Address: 123 Test St, Testville, Test, 01234")
     end
+
+    it 'Displays only my Items in the Order' do
+      visit dashboard_order_path(@order)
+
+      within("#item-#{@item_1.id}") do
+        expect(page).to have_button(@item_1.name, href: item_path(@item_1))
+        find "img[src='https://kaaskraam.com/wp-content/uploads/2018/02/Gouda-Belegen.jpg']"
+        expect(page).to have_content(@item_1.price)
+        expect(page).to have_content(@order_item_1.quantity)
+      end
+
+      within("#item-#{@item_2.id}") do
+        expect(page).to have_button(@item_2.name, href: item_path(@item_1))
+        find "img[src='https://kaaskraam.com/wp-content/uploads/2018/02/Gouda-Belegen.jpg']"
+        expect(page).to have_content(@item_2.price)
+        expect(page).to have_content(@order_item_2.quantity)
+      end
+
+      expect(page).to_not have_css("#item-#{@item_3.id}")
+    end
   end
 end

--- a/spec/features/merchants/orders/show_spec.rb
+++ b/spec/features/merchants/orders/show_spec.rb
@@ -32,14 +32,14 @@ RSpec.describe 'As a merchant', type: :feature do
       visit dashboard_order_path(@order)
 
       within("#item-#{@item_1.id}") do
-        expect(page).to have_button(@item_1.name, href: item_path(@item_1))
+        expect(page).to have_link(@item_1.name, href: item_path(@item_1))
         find "img[src='https://kaaskraam.com/wp-content/uploads/2018/02/Gouda-Belegen.jpg']"
         expect(page).to have_content(@item_1.price)
         expect(page).to have_content(@order_item_1.quantity)
       end
 
       within("#item-#{@item_2.id}") do
-        expect(page).to have_button(@item_2.name, href: item_path(@item_1))
+        expect(page).to have_link(@item_2.name, href: item_path(@item_2))
         find "img[src='https://kaaskraam.com/wp-content/uploads/2018/02/Gouda-Belegen.jpg']"
         expect(page).to have_content(@item_2.price)
         expect(page).to have_content(@order_item_2.quantity)


### PR DESCRIPTION
This PR brings in the functionality for a Merchant to view a Show page of one of their Orders. Since the Order might have items from multiple merchants, this Show page will only show relevant Items. 
The Show page shows the Ordering Users Name, and their full Address.
It also has a section for each Item belonging to the current Merchant that includes a link to an Item Show page, the thumbnail for the Item, the Price, and the Quantity that the User needs fulfilled.

Resolves #31 