### PR TITLE
Merchant Order Item Fulfillment

### DIFF
--- a/app/controllers/merchants/order_items_controller.rb
+++ b/app/controllers/merchants/order_items_controller.rb
@@ -1,0 +1,11 @@
+class Merchants::OrderItemsController < ApplicationController
+  def update
+    order_item = OrderItem.find(params[:id])
+    order = Order.find(order_item.order_id)
+
+    order_item.update(fulfilled: true)
+    flash[:notice] = "Item '#{order_item.item.name}' fulfilled."
+
+    redirect_to dashboard_order_path(order)
+  end
+end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -5,7 +5,7 @@ class OrderItem < ApplicationRecord
   validates_presence_of :quantity, :price
   validates_inclusion_of :fulfilled, in: [true, false]
 
-  after_save :update_inventory, :check_order
+  after_save :update_inventory, :check_order, unless: :just_created?
 
   def sub_total
     quantity * price
@@ -32,5 +32,9 @@ class OrderItem < ApplicationRecord
         order.check_fulfillments
       end
     end
+  end
+
+  def just_created?
+    created_at == updated_at
   end
 end

--- a/app/views/merchants/orders/show.html.erb
+++ b/app/views/merchants/orders/show.html.erb
@@ -10,7 +10,7 @@
     <img src=<%= item.image %> alt="<%= item.name %> Image">
     <p><%= item.price %></p>
     <p><%= order_item.quantity %></p>
-    <%= button_to "Fulfill Item", dashboard_order_item_path(order_item), disabled: (order_item.fulfilled? || order_item.quantity > item.inventory) %>
+    <%= button_to "Fulfill Item", dashboard_order_item_path(order_item), method: :patch, disabled: (order_item.fulfilled? || order_item.quantity > item.inventory) %>
     <% if order_item.fulfilled? %>
       <p>You have already fulfilled this item!</p>
     <% elsif order_item.quantity > item.inventory %>

--- a/app/views/merchants/orders/show.html.erb
+++ b/app/views/merchants/orders/show.html.erb
@@ -7,12 +7,14 @@
 <% item = order_item.item %>
   <section id="item-<%= item.id %>">
     <%= link_to item.name, item_path(item) %>
-    <img src=<%= item.image %> %> alt="<%= item.name %> Image">
+    <img src=<%= item.image %> alt="<%= item.name %> Image">
     <p><%= item.price %></p>
     <p><%= order_item.quantity %></p>
-    <%= button_to "Fulfill Item", dashboard_order_item_path(order_item), disabled: order_item.fulfilled? %>
+    <%= button_to "Fulfill Item", dashboard_order_item_path(order_item), disabled: (order_item.fulfilled? || order_item.quantity > item.inventory) %>
     <% if order_item.fulfilled? %>
       <p>You have already fulfilled this item!</p>
+    <% elsif order_item.quantity > item.inventory %>
+      <p>You do not have enough inventory to fulfill this item!</p>
     <% end %>
   </section>
 <% end %>

--- a/app/views/merchants/orders/show.html.erb
+++ b/app/views/merchants/orders/show.html.erb
@@ -10,5 +10,9 @@
     <img src=<%= item.image %> %> alt="<%= item.name %> Image">
     <p><%= item.price %></p>
     <p><%= order_item.quantity %></p>
+    <%= button_to "Fulfill Item", dashboard_order_item_path(order_item), disabled: order_item.fulfilled? %>
+    <% if order_item.fulfilled? %>
+      <p>You have already fulfilled this item!</p>
+    <% end %>
   </section>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,8 @@ Rails.application.routes.draw do
   patch 'merchants/items/disable/:id', to: 'merchants/items#disable'
 
   scope module: 'merchants', path: 'dashboard', as: :dashboard do
-    resources :items, only: [:index, :new, :edit, :show, :destroy]
+    resources :items, only: [:index, :new, :create, :edit, :show, :destroy]
+    resources :order_items, only: [:update]
     resources :orders, only: [:index, :show, :edit]
   end
 

--- a/spec/features/merchants/orders/show_spec.rb
+++ b/spec/features/merchants/orders/show_spec.rb
@@ -47,5 +47,20 @@ RSpec.describe 'As a merchant', type: :feature do
 
       expect(page).to_not have_css("#item-#{@item_3.id}")
     end
+
+    it 'Should have a Fulfill button on unfulfilled items, and a disabled button on fulfilled items' do
+      @order_item_2.update(fulfilled: true)
+      @order_item_2.reload
+      visit dashboard_order_path(@order)
+
+      within("#item-#{@item_1.id}") do
+        expect(page).to have_button("Fulfill Item")
+      end
+
+      within("#item-#{@item_2.id}") do
+        expect(page).to have_button("Fulfill Item", disabled: true)
+        expect(page).to have_content("You have already fulfilled this item!")
+      end
+    end
   end
 end

--- a/spec/features/merchants/orders/show_spec.rb
+++ b/spec/features/merchants/orders/show_spec.rb
@@ -75,24 +75,25 @@ RSpec.describe 'As a merchant', type: :feature do
     end
 
     it 'When I fulfill the Item, I see a flash notice, can no longer fulfill the Item, and the Item inventory is reduced' do
+      original_inventory = @item_1.inventory
       visit dashboard_order_path(@order)
 
       within("#item-#{@item_1.id}") do
         click_button "Fulfill Item"
-
-        @item_1.reload
-
-        expect(current_path).to eq(dashboard_order_path(@order))
-
-        expect(page).to have_content("Item '#{@item_1.name}' fulfilled.")
-
-        within("#item-#{@item_1.id}") do
-          expect(page).to have_button("Fulfill Item", disabled: true)
-          expect(page).to have_content("You have already fulfilled this item!")
-        end
-
-        expect(@item_1.inventory).to eq(@item_1.inventory - @order_item_1.quantity)
       end
+
+      @item_1.reload
+
+      expect(current_path).to eq(dashboard_order_path(@order))
+
+      expect(page).to have_content("Item '#{@item_1.name}' fulfilled.")
+
+      within("#item-#{@item_1.id}") do
+        expect(page).to have_button("Fulfill Item", disabled: true)
+        expect(page).to have_content("You have already fulfilled this item!")
+      end
+
+      expect(@item_1.inventory).to eq(original_inventory - @order_item_1.quantity)
     end
   end
 end

--- a/spec/features/merchants/orders/show_spec.rb
+++ b/spec/features/merchants/orders/show_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'As a merchant', type: :feature do
     end
 
     it 'Should not allow me to fulfill an item if the inventory is too low' do
-      @order_item_2.update(quantity: 11)
+      @order_item_2.update(quantity: 12)
       @order_item_2.reload
       visit dashboard_order_path(@order)
 

--- a/spec/features/merchants/orders/show_spec.rb
+++ b/spec/features/merchants/orders/show_spec.rb
@@ -62,5 +62,16 @@ RSpec.describe 'As a merchant', type: :feature do
         expect(page).to have_content("You have already fulfilled this item!")
       end
     end
+
+    it 'Should not allow me to fulfill an item if the inventory is too low' do
+      @order_item_2.update(quantity: 11)
+      @order_item_2.reload
+      visit dashboard_order_path(@order)
+
+      within("#item-#{@item_2.id}") do
+        expect(page).to have_button("Fulfill Item", disabled: true)
+        expect(page).to have_content("You do not have enough inventory to fulfill this item!")
+      end
+    end
   end
 end

--- a/spec/features/merchants/orders/show_spec.rb
+++ b/spec/features/merchants/orders/show_spec.rb
@@ -73,5 +73,26 @@ RSpec.describe 'As a merchant', type: :feature do
         expect(page).to have_content("You do not have enough inventory to fulfill this item!")
       end
     end
+
+    it 'When I fulfill the Item, I see a flash notice, can no longer fulfill the Item, and the Item inventory is reduced' do
+      visit dashboard_order_path(@order)
+
+      within("#item-#{@item_1.id}") do
+        click_button "Fulfill Item"
+
+        @item_1.reload
+
+        expect(current_path).to eq(dashboard_order_path(@order))
+
+        expect(page).to have_content("Item '#{@item_1.name}' fulfilled.")
+
+        within("#item-#{@item_1.id}") do
+          expect(page).to have_button("Fulfill Item", disabled: true)
+          expect(page).to have_content("You have already fulfilled this item!")
+        end
+
+        expect(@item_1.inventory).to eq(@item_1.inventory - @order_item_1.quantity)
+      end
+    end
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -102,6 +102,7 @@ RSpec.describe Order, type: :model do
       order_1.reload
       expect(order_1.status).to eq("pending")
 
+      travel_to Time.zone.local(2044, 04, 12, 8, 00, 00)
       order_item_3.update!(fulfilled: true)
       order_item_3.reload
       order_1.reload


### PR DESCRIPTION
This PR brings in the functionality for a Merchant to Fulfill Items on Orders they have Items in. This is done through the Dashboard Order Show Page, where a button will be enabled if they have the ability to Fulfill the Item.
For the button to be enabled, the Merchant has to have not already fulfilled the Item and have enough of the Item in their Item Inventory. If they do not have enough Inventory to Fulfill the Item, they will be shown a message stating as much, and the button will be disabled. Similarly, if the Item has already been Fulfilled, they will be shown a message letting them know and the button will be disabled.
This functionality brought to light an issue with the OrderItems model that was using `after_save` callback functions. These functions were being called whenever an OrderItem was saved, including when it was created. This required the `unless:` clause, to check if the `created_at` and `updated_at` values were the same, indicating a Create action, as opposed to an Update action on the resource. Tests have been updated to expect the correct values.

Resolves #30 #29 