### PR TITLE
User Create Update/Merchants Enable Disable refactor

### DIFF
--- a/app/controllers/merchants_controller.rb
+++ b/app/controllers/merchants_controller.rb
@@ -21,8 +21,6 @@ class MerchantsController < ApplicationController
     user = User.find_by(id: params[:id])
     if User.update(user.id, active: false)
       flash[:notice] = "Merchant's account is now disabled"
-    else
-      flash[:notice] = "Error on updating"
     end
     redirect_to merchants_path
   end
@@ -31,10 +29,7 @@ class MerchantsController < ApplicationController
     user = User.find_by(id: params[:id])
     if User.update(user.id, active: true)
       flash[:notice] = "Merchant's account is now enabled"
-    else
-      flash[:notice] = "Error on updating"
     end
     redirect_to merchants_path
   end
 end
-

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,15 +11,11 @@ class UsersController < ApplicationController
     if password_confirmation != true
       flash.now[:notice] = "Those passwords don't match."
       render :new
-    elsif email_confirmation == true
-      flash.now[:notice] = "That email address is already taken."
-      render :new
     elsif @user.save
       session[:user_id] = @user.id
       flash[:notice] = "You are now registered and logged in."
       redirect_to profile_path
     else
-      flash.now[:notice] = "That didn't work, please try again."
       render :new
     end
   end
@@ -38,13 +34,12 @@ class UsersController < ApplicationController
       flash.now[:notice] = "Those passwords don't match."
       render :edit
     elsif email_confirmation(@user.email) == true
-      flash.now[:notice] = "That email address is already taken."
+      flash[:notice] = "Email has already been taken"
       render :edit
-    elsif @user.update!(user_params)
+    elsif @user.update(user_params)
       flash[:notice] = "Your information has been updated!"
       redirect_to profile_path
     else
-      flash.now[:notice] = "That didn't work, please try again."
       render :edit
     end
   end

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,5 +1,9 @@
 <h2>Edit <%= @user.name %>'s Profile</h2>
 
+<% @user.errors.full_messages.each do |msg| %>
+  <%= msg %>
+<% end %>
+
 <%= form_for @user, url: profile_edit_path do |f| %>
 
 <p><%= f.label :name %></p>

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -108,9 +108,35 @@ RSpec.describe 'As a registered User', type: :feature do
         click_button "Edit User"
 
         expect(current_path).to eq(profile_edit_path)
-        expect(page).to have_content("That email address is already taken.")
+        expect(page).to have_content("Email has already been taken")
 
         expect(page).to have_field("Email", with: "test@test.com")
+      end
+
+      it 'Will not allow not matching passwords' do
+        visit profile_edit_path
+
+        fill_in 'Password', with: 'password'
+        fill_in 'Confirm Password', with: 'password3'
+
+        click_button "Edit User"
+
+        expect(current_path).to eq(profile_edit_path)
+        expect(page).to have_content("Those passwords don't match.")
+      end
+
+      it 'Will not allow blank fields' do
+        visit profile_edit_path
+
+        fill_in 'Name', with: ''
+        fill_in 'Email', with: ''
+
+        click_button "Edit User"
+
+
+        expect(current_path).to eq(profile_edit_path)
+        expect(page).to have_content("Email can't be blank")
+        expect(page).to have_content("Name can't be blank")
       end
     end
   end

--- a/spec/features/users/new_spec.rb
+++ b/spec/features/users/new_spec.rb
@@ -9,15 +9,7 @@ RSpec.describe 'New user form' do
       end
 
       it 'I can register as a new user' do
-
-
-        visit root_path
-
-        within '.navbar' do
-          click_link('Register')
-        end
-
-        expect(current_path).to eq(register_path)
+        visit register_path
 
         fill_in 'Name', with: 'User'
         fill_in 'Address', with: '1111 South One St.'
@@ -30,9 +22,7 @@ RSpec.describe 'New user form' do
 
         click_button 'Create User'
 
-
         new_user = User.last
-
 
         expect(current_path).to eq("/profile")
 
@@ -42,18 +32,10 @@ RSpec.describe 'New user form' do
         expect(page).to have_content("Zip Code: #{new_user.zip}")
         expect(page).to have_content("Email: #{new_user.email}")
         expect(page).to have_content("You are now registered and logged in.")
-
       end
 
       it 'I throws flash message when password isnt the same' do
-
-
-        visit root_path
-
-        click_link('Register')
-
-
-        expect(current_path).to eq(register_path)
+        visit register_path
 
         fill_in 'Name', with: 'User'
         fill_in 'Address', with: '1111 South One St.'
@@ -66,25 +48,16 @@ RSpec.describe 'New user form' do
 
         click_button 'Create User'
 
-
-        new_user = User.last
-
-
         expect(current_path).to eq(register_path)
 
         expect(page).to have_content("Those passwords don't match.")
-
       end
 
 
       it 'Can not use an already used email address' do
         user_2 = User.create!(name: "User_1", role: 0, active: true, password_digest: "8320280282", address: "333", city: "Denver", zip: "80000", email: "user_1@gmail.com", state: 'IL' )
 
-        visit root_path
-
-        within '.navbar' do
-          click_link('Register')
-        end
+        visit register_path
 
         fill_in 'Name', with: 'User_2'
         fill_in 'Address', with: '1111 South One St.'
@@ -98,17 +71,13 @@ RSpec.describe 'New user form' do
         click_button 'Create User'
 
         new_user = User.last
-        expect(page).to have_content("That email address is already taken.")
+        expect(page).to have_content("Email has already been taken")
         expect(new_user.name).to eq('User_1')
       end
     end
 
     it 'Will not let me register if fields are missing' do
-      visit root_path
-
-      within '.navbar' do
-        click_link('Register')
-      end
+      visit register_path
 
       fill_in 'Name', with: ''
       fill_in 'Address', with: '1111 South One St.'
@@ -128,9 +97,3 @@ RSpec.describe 'New user form' do
     end
   end
 end
-#
-# As a visitor
-# When I visit the user registration page
-# And I do not fill in this form completely,
-# I am returned to the registration page
-# And I see a flash message indicating that I am missing required fields


### PR DESCRIPTION
This PR brings in the code cleanup in the Users Controller where a User is being created or updated. Previously, these actions would check manually if the Email was not already existing in the DB and then returning a custom message. Now, these actions use the built in messages where possible, removing code debt.
This required the user.errors.full_messages loop at the top of the User Edit page, that we have already on the User New page.
Additionally, the Merchants controller had a sadpath for Enable and Disable that would never happen under reasonable circumstances, so I have removed it.