### PR TITLE
Merchant Dashboard To Do list

### DIFF
--- a/app/controllers/merchants/orders_controller.rb
+++ b/app/controllers/merchants/orders_controller.rb
@@ -9,5 +9,6 @@ class Merchants::OrdersController < Merchants::BaseController
   def index
     @user = current_user
     @orders = @user.pending_orders
+    @placeholder_image_items = @user.placeholder_image_items
   end
 end

--- a/app/controllers/merchants/orders_controller.rb
+++ b/app/controllers/merchants/orders_controller.rb
@@ -10,5 +10,7 @@ class Merchants::OrdersController < Merchants::BaseController
     @user = current_user
     @orders = @user.pending_orders
     @placeholder_image_items = @user.placeholder_image_items
+    @unfulfilled_items = @user.unfulfilled_items
+    @unfulfilled_items_cost = @user.unfulfilled_items_cost
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -93,6 +93,10 @@ class User < ApplicationRecord
           distinct(:orders)
   end
 
+  def placeholder_image_items
+    items.where("items.image = 'https://kaaskraam.com/wp-content/uploads/2018/02/Gouda-Belegen.jpg'")
+  end
+
   def self.top_3_merchants_by_sales
     self.joins(items: :order_items)
         .joins('JOIN orders ON order_items.order_id=orders.id')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -93,9 +93,25 @@ class User < ApplicationRecord
           distinct(:orders)
   end
 
+  ## EXTENSIONS
+
   def placeholder_image_items
     items.where("items.image = 'https://kaaskraam.com/wp-content/uploads/2018/02/Gouda-Belegen.jpg'")
   end
+
+  def unfulfilled_items
+    pending_orders.where("order_items.fulfilled = false")
+                  .select("order_items.*")
+  end
+
+  def unfulfilled_items_cost
+    pending_orders.where("order_items.fulfilled = false")
+                  .select("order_items.*")
+                  .distinct(false)
+                  .sum("order_items.quantity * order_items.price")
+  end
+
+  ## END EXTENSIONS
 
   def self.top_3_merchants_by_sales
     self.joins(items: :order_items)

--- a/app/views/merchants/orders/index.html.erb
+++ b/app/views/merchants/orders/index.html.erb
@@ -10,6 +10,26 @@
 <p>State: <%= @user.state %></p>
 <p>Zip Code: <%= @user.zip %></p>
 
+<section id="to-do-list">
+  <div class="card-header">
+    To Do List
+  </div>
+  <div class="card-body">
+    <% unless @placeholder_image_items.count.empty? %>
+      <span id="placeholder-images-list">
+        <h5 class="card-title">These items need new images!</h5>
+        <p class="card-text">
+          <ol>
+            <% @placeholder_image_items.each do |item| %>
+              <li><strong><%= link_to item.name, edit_dashboard_item_path(item) %></strong> is currently using the default cheesey image, please fix this!</li>
+            <% end %>
+          </ol>
+        </p>
+      </span>
+    <% end %>
+  </div>
+</section>
+
 <% if !@user.items.empty? && !@user.top_items_sold(5).empty?  %>
 
 <div class="card merchant-stats" >
@@ -63,7 +83,7 @@
       <h5 class="card-title">Top Customer by Orders Shipped</h5>
       <p class="card-text">
           <% @user.best_customer_orders.each do |order| %>
-            <strong><%= order.user.name %>:</strong> <%= order.order_count %>, Orders Shipped </li>
+            <li> <strong><%= order.user.name %>:</strong> <%= order.order_count %>, Orders Shipped </li>
           <% end %>
       </p>
     </span>
@@ -72,7 +92,7 @@
       <h5 class="card-title">Top Customer by Items Shipped</h5>
       <p class="card-text">
           <% @user.best_customer_items.each do |order| %>
-            <strong><%= order.name %>:</strong> <%= order.total_bought %>, Items Shipped </li>
+            <li> <strong><%= order.name %>:</strong> <%= order.total_bought %>, Items Shipped </li>
           <% end %>
       </p>
     </span>

--- a/app/views/merchants/orders/index.html.erb
+++ b/app/views/merchants/orders/index.html.erb
@@ -16,33 +16,33 @@
       To Do List
     </div>
     <div class="card-body">
-      <% if @placeholder_image_items.empty? %>
       <span id="placeholder-images-list">
-        <h5 class="card-title">All of your items have new images!</h5>
+        <% if @placeholder_image_items.empty? %>
+          <h5 class="card-title">All of your items have new images!</h5>
+        <% else %>
+            <h5 class="card-title">These items need new images!</h5>
+            <p class="card-text">
+              <ol>
+                <% @placeholder_image_items.each do |item| %>
+                  <li><strong><%= link_to item.name, edit_dashboard_item_path(item) %></strong> is currently using the default cheesey image, please fix this!</li>
+                <% end %>
+              </ol>
+            </p>
+        <% end %>
       </span>
-      <% else %>
-        <span id="placeholder-images-list">
-          <h5 class="card-title">These items need new images!</h5>
-          <p class="card-text">
-            <ol>
-              <% @placeholder_image_items.each do |item| %>
-                <li><strong><%= link_to item.name, edit_dashboard_item_path(item) %></strong> is currently using the default cheesey image, please fix this!</li>
-              <% end %>
-            </ol>
-          </p>
-        </span>
-      <% end %>
     </div>
 
     <div class="card-body">
-      <% unless @unfulfilled_items.empty? %>
-        <span id="unfulfilled-items">
-          <h5 class="card-title">Unfulfilled Items</h5>
-          <p class="card-text">
-            You have <%= @unfulfilled_items.count %> unfulfilled orders worth <%= number_to_currency(@unfulfilled_items_cost) %>
-          </p>
-        </span>
-      <% end %>
+      <span id="unfulfilled-items">
+        <% if @unfulfilled_items.empty? %>
+          <h5 class="card-title">All of your items are fulfilled!</h5>
+        <% else %>
+            <h5 class="card-title">Unfulfilled Items</h5>
+            <p class="card-text">
+              You have <%= @unfulfilled_items.count %> unfulfilled orders worth <%= number_to_currency(@unfulfilled_items_cost) %>
+            </p>
+        <% end %>
+      </span>
     </div>
   </section>
 <% end %>

--- a/app/views/merchants/orders/index.html.erb
+++ b/app/views/merchants/orders/index.html.erb
@@ -16,7 +16,11 @@
       To Do List
     </div>
     <div class="card-body">
-      <% unless @placeholder_image_items.empty? %>
+      <% if @placeholder_image_items.empty? %>
+      <span id="placeholder-images-list">
+        <h5 class="card-title">All of your items have new images!</h5>
+      </span>
+      <% else %>
         <span id="placeholder-images-list">
           <h5 class="card-title">These items need new images!</h5>
           <p class="card-text">

--- a/app/views/merchants/orders/index.html.erb
+++ b/app/views/merchants/orders/index.html.erb
@@ -29,6 +29,17 @@
         </span>
       <% end %>
     </div>
+
+    <div class="card-body">
+      <% unless @unfulfilled_items.empty? %>
+        <span id="unfulfilled-items">
+          <h5 class="card-title">Unfulfilled Items</h5>
+          <p class="card-text">
+            You have <%= @unfulfilled_items.count %> unfulfilled orders worth <%= number_to_currency(@unfulfilled_items_cost) %>
+          </p>
+        </span>
+      <% end %>
+    </div>
   </section>
 <% end %>
 

--- a/app/views/merchants/orders/index.html.erb
+++ b/app/views/merchants/orders/index.html.erb
@@ -10,25 +10,27 @@
 <p>State: <%= @user.state %></p>
 <p>Zip Code: <%= @user.zip %></p>
 
-<section id="to-do-list">
-  <div class="card-header">
-    To Do List
-  </div>
-  <div class="card-body">
-    <% unless @placeholder_image_items.count.empty? %>
-      <span id="placeholder-images-list">
-        <h5 class="card-title">These items need new images!</h5>
-        <p class="card-text">
-          <ol>
-            <% @placeholder_image_items.each do |item| %>
-              <li><strong><%= link_to item.name, edit_dashboard_item_path(item) %></strong> is currently using the default cheesey image, please fix this!</li>
-            <% end %>
-          </ol>
-        </p>
-      </span>
-    <% end %>
-  </div>
-</section>
+<% if current_merchant? %>
+  <section id="to-do-list">
+    <div class="card-header">
+      To Do List
+    </div>
+    <div class="card-body">
+      <% unless @placeholder_image_items.empty? %>
+        <span id="placeholder-images-list">
+          <h5 class="card-title">These items need new images!</h5>
+          <p class="card-text">
+            <ol>
+              <% @placeholder_image_items.each do |item| %>
+                <li><strong><%= link_to item.name, edit_dashboard_item_path(item) %></strong> is currently using the default cheesey image, please fix this!</li>
+              <% end %>
+            </ol>
+          </p>
+        </span>
+      <% end %>
+    </div>
+  </section>
+<% end %>
 
 <% if !@user.items.empty? && !@user.top_items_sold(5).empty?  %>
 

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -114,6 +114,20 @@ RSpec.describe 'Merchant show page', type: :feature do
         end
       end
 
+      it 'should tell me that all my items do not have placeholder images' do
+        visit dashboard_path
+
+        within("#placeholder-images-list") do
+          expect(page).to have_content("All of your items have new images!")
+
+          expect(page).to_not have_content("#{@item_1.name} is currently using the default cheesey image, please fix this!")
+          expect(page).to_not have_link(@item_1.name, href: edit_dashboard_item_path(@item_1))
+
+          expect(page).to_not have_content("#{@item_4.name} is currently using the default cheesey image, please fix this!")
+          expect(page).to_not have_link(@item_4.name, href: edit_dashboard_item_path(@item_4))
+        end
+      end
+
       it 'should tell me about my unfulfilled items and how much they are worth' do
         @order_item_5 = OrderItem.create!(item: @item_3, order: @order_1, quantity: 15, price: 1.99, fulfilled: false)
         visit dashboard_path

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe 'Merchant show page', type: :feature do
       it 'should tell me about placeholder images for cheeses I own' do
         visit dashboard_path
 
-        within("#to-do-list") do
+        within("#placeholder-images-list") do
           expect(page).to have_content("#{@item_5.name} is currently using the default cheesey image, please fix this!")
           expect(page).to have_link(@item_5.name, href: edit_dashboard_item_path(@item_5))
         end

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -74,5 +74,38 @@ RSpec.describe 'Merchant show page', type: :feature do
         expect(page).to have_content("Item Id: #{@item_4.id}")
       end
     end
+
+    describe 'To Do List' do
+      before :each do
+        @merchant = create(:user, role: 1)
+        @item_1 = create(:item, user: @merchant)
+        @item_2 = create(:item, user: @merchant)
+        @item_3 = create(:item, user: @merchant)
+        @item_4 = create(:item, user: @merchant)
+        @item_5 = Item.create!(name: "TestCheese", active: true, price: 10.00, description: "This cheese should have the default image.", image: "", inventory: 100)
+        @user_1 = create(:user)
+        @user_2 = create(:user)
+        @user_3 = create(:user)
+        @order_1 = create(:order, user: @user_1, status: 1)
+        @order_2 = create(:order, user: @user_2, status: 1)
+        @order_3 = create(:order, user: @user_3, status: 0)
+        @order_4 = create(:order, user: @user_3, status: 0)
+        OrderItem.create!(item: @item_1, order: @order_1, quantity: 12, price: 1.99, fulfilled: true)
+        OrderItem.create!(item: @item_2, order: @order_2, quantity: 13, price: 1.99, fulfilled: false)
+        OrderItem.create!(item: @item_3, order: @order_3, quantity: 14, price: 1.99, fulfilled: true)
+        OrderItem.create!(item: @item_3, order: @order_4, quantity: 15, price: 1.99, fulfilled: false)
+
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
+      end
+
+      it 'should tell me about placeholder images for cheeses I own' do
+        visit dashboard_path
+
+        within("#to-do-list") do
+          expect(page).to have_content("#{@item_5.name} is currently using the default cheesey image, please fix this!")
+          expect(page).to have_link(@item_5.name, href: edit_dashboard_item_path(@item_5))
+        end
+      end
+    end
   end
 end

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+include ActionView::Helpers::NumberHelper
 
 RSpec.describe 'Merchant show page', type: :feature do
   context 'As a merchant user' do
@@ -90,9 +91,9 @@ RSpec.describe 'Merchant show page', type: :feature do
         @order_2 = create(:order, user: @user_2, status: 1)
         @order_3 = create(:order, user: @user_3, status: 0)
         @order_4 = create(:order, user: @user_3, status: 0)
-        @order_item_1 = OrderItem.create!(item: @item_1, order: @order_1, quantity: 12, price: 1.99, fulfilled: true)
+        @order_item_1 = OrderItem.create!(item: @item_1, order: @order_1, quantity: 12, price: 1.99, fulfilled: false)
         @order_item_2 = OrderItem.create!(item: @item_2, order: @order_2, quantity: 13, price: 1.99, fulfilled: false)
-        @order_item_3 = OrderItem.create!(item: @item_3, order: @order_3, quantity: 14, price: 1.99, fulfilled: true)
+        @order_item_3 = OrderItem.create!(item: @item_3, order: @order_3, quantity: 14, price: 1.99, fulfilled: false)
         @order_item_4 = OrderItem.create!(item: @item_3, order: @order_4, quantity: 15, price: 1.99, fulfilled: false)
 
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
@@ -111,12 +112,13 @@ RSpec.describe 'Merchant show page', type: :feature do
       end
 
       it 'should tell me about my unfulfilled items and how much they are worth' do
+        @order_item_5 = OrderItem.create!(item: @item_3, order: @order_1, quantity: 15, price: 1.99, fulfilled: false)
         visit dashboard_path
 
         within("#unfulfilled-items") do
           expect(page).to have_content("Unfulfilled Items")
 
-          expect(page).to have_content("You have 2 unfulfilled orders worth #{number_to_currency((@order_item_2.price * @order_item_2.quantity) + (@order_item_4.price * @order_item_4.quantity))}")
+          expect(page).to have_content("You have #{@merchant.unfulfilled_items.count} unfulfilled orders worth #{number_to_currency((@order_item_2.price * @order_item_2.quantity) + (@order_item_1.price * @order_item_1.quantity) + (@order_item_5.price * @order_item_5.quantity))}")
         end
       end
     end

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -90,10 +90,10 @@ RSpec.describe 'Merchant show page', type: :feature do
         @order_2 = create(:order, user: @user_2, status: 1)
         @order_3 = create(:order, user: @user_3, status: 0)
         @order_4 = create(:order, user: @user_3, status: 0)
-        OrderItem.create!(item: @item_1, order: @order_1, quantity: 12, price: 1.99, fulfilled: true)
-        OrderItem.create!(item: @item_2, order: @order_2, quantity: 13, price: 1.99, fulfilled: false)
-        OrderItem.create!(item: @item_3, order: @order_3, quantity: 14, price: 1.99, fulfilled: true)
-        OrderItem.create!(item: @item_3, order: @order_4, quantity: 15, price: 1.99, fulfilled: false)
+        @order_item_1 = OrderItem.create!(item: @item_1, order: @order_1, quantity: 12, price: 1.99, fulfilled: true)
+        @order_item_2 = OrderItem.create!(item: @item_2, order: @order_2, quantity: 13, price: 1.99, fulfilled: false)
+        @order_item_3 = OrderItem.create!(item: @item_3, order: @order_3, quantity: 14, price: 1.99, fulfilled: true)
+        @order_item_4 = OrderItem.create!(item: @item_3, order: @order_4, quantity: 15, price: 1.99, fulfilled: false)
 
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
       end
@@ -107,6 +107,16 @@ RSpec.describe 'Merchant show page', type: :feature do
 
           expect(page).to have_content("#{@item_5.name} is currently using the default cheesey image, please fix this!")
           expect(page).to have_link(@item_5.name, href: edit_dashboard_item_path(@item_5))
+        end
+      end
+
+      it 'should tell me about my unfulfilled items and how much they are worth' do
+        visit dashboard_path
+
+        within("#unfulfilled-items") do
+          expect(page).to have_content("Unfulfilled Items")
+
+          expect(page).to have_content("You have 2 unfulfilled orders worth #{number_to_currency((@order_item_2.price * @order_item_2.quantity) + (@order_item_4.price * @order_item_4.quantity))}")
         end
       end
     end

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -138,6 +138,21 @@ RSpec.describe 'Merchant show page', type: :feature do
           expect(page).to have_content("You have #{@merchant.unfulfilled_items.count} unfulfilled orders worth #{number_to_currency((@order_item_2.price * @order_item_2.quantity) + (@order_item_1.price * @order_item_1.quantity) + (@order_item_5.price * @order_item_5.quantity))}")
         end
       end
+
+      it 'should tell me about I have fulfilled all my items' do
+        @order_item_1.update(fulfilled: true)
+        @order_item_2.update(fulfilled: true)
+        @order_item_2.reload
+        @order_item_2.reload
+        @order_item_5 = OrderItem.create!(item: @item_3, order: @order_1, quantity: 15, price: 1.99, fulfilled: true)
+        visit dashboard_path
+
+        within("#unfulfilled-items") do
+          expect(page).to have_content("All of your items are fulfilled!")
+
+          expect(page).to_not have_content("You have #{@merchant.unfulfilled_items.count} unfulfilled orders worth #{number_to_currency((@order_item_2.price * @order_item_2.quantity) + (@order_item_1.price * @order_item_1.quantity) + (@order_item_5.price * @order_item_5.quantity))}")
+        end
+      end
     end
   end
 end

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -106,6 +106,9 @@ RSpec.describe 'Merchant show page', type: :feature do
         within("#placeholder-images-list") do
           expect(page).to have_content("These items need new images!")
 
+          expect(page).to_not have_content("#{@item_1.name} is currently using the default cheesey image, please fix this!")
+          expect(page).to_not have_link(@item_1.name, href: edit_dashboard_item_path(@item_1))
+
           expect(page).to have_content("#{@item_5.name} is currently using the default cheesey image, please fix this!")
           expect(page).to have_link(@item_5.name, href: edit_dashboard_item_path(@item_5))
         end

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -78,11 +78,11 @@ RSpec.describe 'Merchant show page', type: :feature do
     describe 'To Do List' do
       before :each do
         @merchant = create(:user, role: 1)
-        @item_1 = create(:item, user: @merchant)
-        @item_2 = create(:item, user: @merchant)
-        @item_3 = create(:item, user: @merchant)
-        @item_4 = create(:item, user: @merchant)
-        @item_5 = Item.create!(name: "TestCheese", active: true, price: 10.00, description: "This cheese should have the default image.", image: "", inventory: 100)
+        @item_1 = create(:item, user: @merchant, image: "https://cdn.shopify.com/s/files/1/0150/0232/products/Pearl_Valley_Swiss_Slices_36762caf-0757-45d2-91f0-424bcacc9892_large.jpg?v=1534871055")
+        @item_2 = create(:item, user: @merchant, image: "https://cdn.shopify.com/s/files/1/0150/0232/products/Pearl_Valley_Swiss_Slices_36762caf-0757-45d2-91f0-424bcacc9892_large.jpg?v=1534871055")
+        @item_3 = create(:item, user: @merchant, image: "https://cdn.shopify.com/s/files/1/0150/0232/products/Pearl_Valley_Swiss_Slices_36762caf-0757-45d2-91f0-424bcacc9892_large.jpg?v=1534871055")
+        @item_4 = create(:item, user: @merchant, image: "https://cdn.shopify.com/s/files/1/0150/0232/products/Pearl_Valley_Swiss_Slices_36762caf-0757-45d2-91f0-424bcacc9892_large.jpg?v=1534871055")
+
         @user_1 = create(:user)
         @user_2 = create(:user)
         @user_3 = create(:user)
@@ -99,9 +99,12 @@ RSpec.describe 'Merchant show page', type: :feature do
       end
 
       it 'should tell me about placeholder images for cheeses I own' do
+        @item_5 = Item.create!(name: "TestCheese", active: true, price: 10.00, description: "This cheese should have the default image.", image: "https://kaaskraam.com/wp-content/uploads/2018/02/Gouda-Belegen.jpg", inventory: 100, user: @merchant)
         visit dashboard_path
 
         within("#placeholder-images-list") do
+          expect(page).to have_content("These items need new images!")
+
           expect(page).to have_content("#{@item_5.name} is currently using the default cheesey image, please fix this!")
           expect(page).to have_link(@item_5.name, href: edit_dashboard_item_path(@item_5))
         end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -231,10 +231,10 @@ RSpec.describe User, type: :model do
       @order_2 = create(:order, user: @user_2, status: 1)
       @order_3 = create(:order, user: @user_3, status: 0)
       @order_4 = create(:order, user: @user_3, status: 0)
-      OrderItem.create!(item: @item_1, order: @order_1, quantity: 12, price: 1.99, fulfilled: false)
-      OrderItem.create!(item: @item_2, order: @order_2, quantity: 12, price: 1.99, fulfilled: false)
-      OrderItem.create!(item: @item_3, order: @order_3, quantity: 12, price: 1.99, fulfilled: false)
-      OrderItem.create!(item: @item_3, order: @order_4, quantity: 12, price: 1.99, fulfilled: false)
+      @order_item_1 = OrderItem.create!(item: @item_1, order: @order_1, quantity: 12, price: 1.99, fulfilled: false)
+      @order_item_2 = OrderItem.create!(item: @item_2, order: @order_2, quantity: 12, price: 1.99, fulfilled: false)
+      @order_item_3 = OrderItem.create!(item: @item_3, order: @order_3, quantity: 12, price: 1.99, fulfilled: false)
+      @order_item_4 = OrderItem.create!(item: @item_3, order: @order_4, quantity: 12, price: 1.99, fulfilled: false)
 
       allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@merchant)
     end
@@ -243,6 +243,26 @@ RSpec.describe User, type: :model do
       orders = [@order_1, @order_2]
 
       expect(@merchant.pending_orders).to eq(orders)
+    end
+
+    it '#placeholder_image_items' do
+      expect(@merchant.placeholder_image_items.count).to eq(4)
+      expect(@merchant.placeholder_image_items.first).to eq(@item_1)
+      expect(@merchant.placeholder_image_items.second).to eq(@item_2)
+      expect(@merchant.placeholder_image_items.third).to eq(@item_3)
+      expect(@merchant.placeholder_image_items.fourth).to eq(@item_4)
+    end
+
+    it '#unfulfilled_items' do
+      # only includes pending orders items, cancelled omitted
+      # Impossible to expect specific items, because they're joined Orders with OrderItem attributes
+      expect(@merchant.unfulfilled_items.count).to eq(2)
+    end
+
+    it '#unfulfilled_items_cost' do
+      # only includes pending orders items, cancelled omitted
+      # require "pry"; binding.pry
+      expect(@merchant.unfulfilled_items_cost).to eq((@order_item_1.price * @order_item_1.quantity) + (@order_item_2.price * @order_item_2.quantity))
     end
   end
 
@@ -340,14 +360,6 @@ RSpec.describe User, type: :model do
       expect(@merchant.top_users[0].name).to eq(@user_3.name)
       expect(@merchant.top_users[1].name).to eq(@user_4.name)
       expect(@merchant.top_users[2].name).to eq(@user_5.name)
-    end
-
-    it '#placeholder_image_items' do
-      expect(@merchant.placeholder_image_items.count).to eq(4)
-      expect(@merchant.placeholder_image_items.first).to eq(@item_1)
-      expect(@merchant.placeholder_image_items.second).to eq(@item_2)
-      expect(@merchant.placeholder_image_items.third).to eq(@item_3)
-      expect(@merchant.placeholder_image_items.fourth).to eq(@item_4)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -341,5 +341,13 @@ RSpec.describe User, type: :model do
       expect(@merchant.top_users[1].name).to eq(@user_4.name)
       expect(@merchant.top_users[2].name).to eq(@user_5.name)
     end
+
+    it '#placeholder_image_items' do
+      expect(@merchant.placeholder_image_items.count).to eq(4)
+      expect(@merchant.placeholder_image_items.first).to eq(@item_1)
+      expect(@merchant.placeholder_image_items.second).to eq(@item_2)
+      expect(@merchant.placeholder_image_items.third).to eq(@item_3)
+      expect(@merchant.placeholder_image_items.fourth).to eq(@item_4)
+    end
   end
 end


### PR DESCRIPTION
This PR brings in the functionality of a To Do list for Merchants that is displayed at the top of their Dashboard. This Todo list includes two sections, one for new Items that are using the Placeholder image, and another for a Total Unfulfilled Item Cost.
The placeholder image section has links to edit those items, where they can replace the image link using the form.
The unfulfilled item cost section takes a count of all items from all pending orders for that Merchant, sees if they are fulfilled, and then sums the sub-total of each OrderItem. This conveniently ignores cancelled orders by using the User.pending_orders method.

There are also edge cases for when there are no Placeholder Images, and also for when all items are fulfilled, leading to a zero cost.