### PR TITLE
Merchant dashboard quantity warnings

### DIFF
--- a/app/controllers/merchants/orders_controller.rb
+++ b/app/controllers/merchants/orders_controller.rb
@@ -12,5 +12,6 @@ class Merchants::OrdersController < Merchants::BaseController
     @placeholder_image_items = @user.placeholder_image_items
     @unfulfilled_items = @user.unfulfilled_items
     @unfulfilled_items_cost = @user.unfulfilled_items_cost
+    @items_exceeding_inventory = @user.items_exceeding_inventory
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -25,12 +25,16 @@ class Order < ApplicationRecord
     end
   end
 
+  def exceeds_inventory?
+    items.joins(:order_items).where("order_items.order_id = #{self.id} AND order_items.fulfilled = false AND order_items.quantity > items.inventory").any?
+  end
+
   def check_fulfillments
     if order_items.all? {|order_item| order_item.fulfilled}
       update(status: :packaged)
     end
   end
-  
+
   def self.biggest_3
     self.joins(:items)
         .select('count(items.id), orders.*')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -111,6 +111,13 @@ class User < ApplicationRecord
                   .sum("order_items.quantity * order_items.price")
   end
 
+  def items_exceeding_inventory
+    items.joins(:orders)
+         .where("orders.status = 1")
+         .having("items.inventory < sum(order_items.quantity)")
+         .group(:id)
+  end
+
   ## END EXTENSIONS
 
   def self.top_3_merchants_by_sales

--- a/app/views/merchants/orders/index.html.erb
+++ b/app/views/merchants/orders/index.html.erb
@@ -134,6 +134,17 @@
   <%= link_to "Downgrade to User", admin_merchant_edit_path({id: @user.id, request: :downgrade_to_user}), :method => :patch, class:"btn btn-primary" %>
 <% end %>
 
+<% if current_merchant? %>
+  <% if @items_exceeding_inventory.any? %>
+    <p>Your orders have quantities exceeding your inventory of: </p>
+    <ol>
+      <% @items_exceeding_inventory.each do |item| %>
+        <li><%= item.name %></li>
+      <% end %>
+    </ol>
+  <% end %>
+<% end %>
+
 <% @orders.each do |order| %>
 <section id="order-<%= order.id %>">
   <p>Order id: <%= link_to "#{order.id}", dashboard_order_path(order.id) %>

--- a/app/views/merchants/orders/index.html.erb
+++ b/app/views/merchants/orders/index.html.erb
@@ -140,5 +140,8 @@
   <p>Date created: <%= order.date_made %></p>
   <p>Total quantity: <%= order.item_count %></p>
   <p>Total price: <%= order.grand_total %></p>
+  <% if order.exceeds_inventory? %>
+    <p>This order has an item that exceeds your current inventory!</p>
+  <% end %>
 </section>
 <% end %>

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -157,11 +157,11 @@ RSpec.describe 'Merchant show page', type: :feature do
       it 'should warn me whenever an individual order has an item exceeding my inventory of that item' do
         visit dashboard_path
 
-        within("#section-#{@order}") do
+        within("#order-#{@order_1.id}") do
           expect(page).to_not have_content("This order has an item that exceeds your current inventory!")
         end
 
-        within("#section-#{@order}") do
+        within("#order-#{@order_2.id}") do
           expect(page).to have_content("This order has an item that exceeds your current inventory!")
         end
       end

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -79,10 +79,10 @@ RSpec.describe 'Merchant show page', type: :feature do
     describe 'To Do List' do
       before :each do
         @merchant = create(:user, role: 1)
-        @item_1 = create(:item, user: @merchant, image: "https://cdn.shopify.com/s/files/1/0150/0232/products/Pearl_Valley_Swiss_Slices_36762caf-0757-45d2-91f0-424bcacc9892_large.jpg?v=1534871055")
-        @item_2 = create(:item, user: @merchant, image: "https://cdn.shopify.com/s/files/1/0150/0232/products/Pearl_Valley_Swiss_Slices_36762caf-0757-45d2-91f0-424bcacc9892_large.jpg?v=1534871055")
-        @item_3 = create(:item, user: @merchant, image: "https://cdn.shopify.com/s/files/1/0150/0232/products/Pearl_Valley_Swiss_Slices_36762caf-0757-45d2-91f0-424bcacc9892_large.jpg?v=1534871055")
-        @item_4 = create(:item, user: @merchant, image: "https://cdn.shopify.com/s/files/1/0150/0232/products/Pearl_Valley_Swiss_Slices_36762caf-0757-45d2-91f0-424bcacc9892_large.jpg?v=1534871055")
+        @item_1 = create(:item, user: @merchant, inventory: 12, image: "https://cdn.shopify.com/s/files/1/0150/0232/products/Pearl_Valley_Swiss_Slices_36762caf-0757-45d2-91f0-424bcacc9892_large.jpg?v=1534871055")
+        @item_2 = create(:item, user: @merchant, inventory: 12, image: "https://cdn.shopify.com/s/files/1/0150/0232/products/Pearl_Valley_Swiss_Slices_36762caf-0757-45d2-91f0-424bcacc9892_large.jpg?v=1534871055")
+        @item_3 = create(:item, user: @merchant, inventory: 12, image: "https://cdn.shopify.com/s/files/1/0150/0232/products/Pearl_Valley_Swiss_Slices_36762caf-0757-45d2-91f0-424bcacc9892_large.jpg?v=1534871055")
+        @item_4 = create(:item, user: @merchant, inventory: 12, image: "https://cdn.shopify.com/s/files/1/0150/0232/products/Pearl_Valley_Swiss_Slices_36762caf-0757-45d2-91f0-424bcacc9892_large.jpg?v=1534871055")
 
         @user_1 = create(:user)
         @user_2 = create(:user)

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -176,6 +176,17 @@ RSpec.describe 'Merchant show page', type: :feature do
 
         expect(page).to have_content("Your orders have quantities exceeding your inventory of:\n#{@item_1.name}")
       end
+
+      it 'should NOT warn me if multiple orders DO NOT have an item exceeding my inventory of that item' do
+        @order_item_1.update(quantity: 1)
+        @order_item_2.update(quantity: 1)
+        @order_item_1.reload
+        @order_item_2.reload
+        @order_item_5 = OrderItem.create!(item: @item_1, order: @order_2, quantity: 2, price: 1.99, fulfilled: false)
+        visit dashboard_path
+
+        expect(page).to_not have_content("Your orders have quantities exceeding your inventory of:\n#{@item_1.name}")
+      end
     end
   end
 end

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -165,6 +165,17 @@ RSpec.describe 'Merchant show page', type: :feature do
           expect(page).to have_content("This order has an item that exceeds your current inventory!")
         end
       end
+
+      it 'should warn me if multiple orders have an item exceeding my inventory of that item' do
+        @order_item_1.update(quantity: 7)
+        @order_item_2.update(quantity: 2)
+        @order_item_1.reload
+        @order_item_2.reload
+        @order_item_5 = OrderItem.create!(item: @item_1, order: @order_2, quantity: 7, price: 1.99, fulfilled: false)
+        visit dashboard_path
+
+        expect(page).to have_content("Your orders have quantities exceeding your inventory of:\n#{@item_1.name}")
+      end
     end
   end
 end

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -153,6 +153,18 @@ RSpec.describe 'Merchant show page', type: :feature do
           expect(page).to_not have_content("You have #{@merchant.unfulfilled_items.count} unfulfilled orders worth #{number_to_currency((@order_item_2.price * @order_item_2.quantity) + (@order_item_1.price * @order_item_1.quantity) + (@order_item_5.price * @order_item_5.quantity))}")
         end
       end
+
+      it 'should warn me whenever an individual order has an item exceeding my inventory of that item' do
+        visit dashboard_path
+
+        within("#section-#{@order}") do
+          expect(page).to_not have_content("This order has an item that exceeds your current inventory!")
+        end
+
+        within("#section-#{@order}") do
+          expect(page).to have_content("This order has an item that exceeds your current inventory!")
+        end
+      end
     end
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -108,6 +108,32 @@ RSpec.describe Order, type: :model do
       order_1.reload
       expect(order_1.status).to eq("packaged")
     end
+
+    it '#exceeds_inventory?' do
+      merchant = create(:user, role: 1)
+      item_1 = create(:item, user: merchant, inventory: 12, image: "https://cdn.shopify.com/s/files/1/0150/0232/products/Pearl_Valley_Swiss_Slices_36762caf-0757-45d2-91f0-424bcacc9892_large.jpg?v=1534871055")
+      item_2 = create(:item, user: merchant, inventory: 12, image: "https://cdn.shopify.com/s/files/1/0150/0232/products/Pearl_Valley_Swiss_Slices_36762caf-0757-45d2-91f0-424bcacc9892_large.jpg?v=1534871055")
+      item_3 = create(:item, user: merchant, inventory: 12, image: "https://cdn.shopify.com/s/files/1/0150/0232/products/Pearl_Valley_Swiss_Slices_36762caf-0757-45d2-91f0-424bcacc9892_large.jpg?v=1534871055")
+      item_4 = create(:item, user: merchant, inventory: 12, image: "https://cdn.shopify.com/s/files/1/0150/0232/products/Pearl_Valley_Swiss_Slices_36762caf-0757-45d2-91f0-424bcacc9892_large.jpg?v=1534871055")
+
+      user_1 = create(:user)
+      user_2 = create(:user)
+      user_3 = create(:user)
+      order_1 = create(:order, user: user_1, status: 1)
+      order_2 = create(:order, user: user_2, status: 1)
+      order_3 = create(:order, user: user_3, status: 0)
+      order_4 = create(:order, user: user_3, status: 0)
+      order_item_1 = OrderItem.create!(item: item_1, order: order_1, quantity: 6, price: 1.99, fulfilled: false)
+      order_item_2 = OrderItem.create!(item: item_2, order: order_2, quantity: 32, price: 1.99, fulfilled: false)
+      order_item_3 = OrderItem.create!(item: item_3, order: order_3, quantity: 19, price: 1.99, fulfilled: false)
+      order_item_4 = OrderItem.create!(item: item_3, order: order_4, quantity: 1, price: 1.99, fulfilled: false)
+
+      expect(order_1.exceeds_inventory?).to eq(false)
+      expect(order_2.exceeds_inventory?).to eq(true)
+      # These two are cancelled so would not ever be called on
+      expect(order_3.exceeds_inventory?).to eq(true)
+      expect(order_4.exceeds_inventory?).to eq(false)
+    end
   end
 
   describe 'class methods' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -264,6 +264,13 @@ RSpec.describe User, type: :model do
       # require "pry"; binding.pry
       expect(@merchant.unfulfilled_items_cost).to eq((@order_item_1.price * @order_item_1.quantity) + (@order_item_2.price * @order_item_2.quantity))
     end
+
+    it '#items_exceeding_inventory' do
+      @order_item_2.update(quantity: 200)
+      @order_item_2.reload
+
+      expect(@merchant.items_exceeding_inventory).to eq([@item_2])
+    end
   end
 
   describe 'instance_methods_us36' do


### PR DESCRIPTION
This PR brings in the functionality for the Merchant Dashboard to display warnings regarding the Orders they need to fulfill. These warnings will display on each Order if there is a single Item in it that has a larger Quantity than there is Inventory. This is done as an instance method on each Order.
The other warning is for if through all Orders that a Merchant has to fulfill the Quantities of all included Items exceeds the Inventory of one of their Items. This will display a warning with a list of Items that will not be able to be completely fulfilled.